### PR TITLE
[Feature Request] add batch option to `td job:result` and `td query`.

### DIFF
--- a/lib/td/command/query.rb
+++ b/lib/td/command/query.rb
@@ -18,6 +18,7 @@ module Command
     sampling_all = nil
     type = nil
     exclude = false
+    batch = false
 
     op.on('-g', '--org ORGANIZATION', "issue the query under this organization") {|s|
       org = s
@@ -70,6 +71,9 @@ module Command
     op.on('-x', '--exclude', 'do not automatically retrieve the job result', TrueClass) {|b|
       exclude = b
     }
+    op.on('-B', '--batch', 'print results using tab as the column separator, with each row on a new line.', TrueClass) {|b|
+      batch = b
+    }
 
     sql = op.cmd_parse
 
@@ -114,7 +118,7 @@ module Command
       puts "Status     : #{job.status}"
       if job.success? && !exclude
         puts "Result     :"
-        show_result(job, output, format, render_opts)
+        show_result(job, output, format, render_opts, batch)
       end
     end
   end


### PR DESCRIPTION
This idea comes from MySQL's batch mode. That mode print the results using tab as the column separator, with each row on a new line.

This feature is very useful when copying the result and past it to Microsoft Excel or some applications.

for example:

```
$ bin/td query -d testdb -B -w "select v['code'] as code, count(1) as cnt from www_access group by v['code']"

 ----------------------------------------------------------------
  MapReduce time taken: 22.501 seconds
  Time taken: 22.782 seconds
Status     : success
Result     :

404 17
500 2
200 4981

```

also I think changing `format` option is good solution too.  It is better to print other format if it enable without `output` option.

Thanks,
