### PR TITLE
Update rubyinstaller, because rubyforge is losted

### DIFF
--- a/dist/exe.rake
+++ b/dist/exe.rake
@@ -4,7 +4,7 @@ task 'exe:build' => :build do
   create_build_dir('exe') do |dir|
     # create ./installers/
     FileUtils.mkdir_p "installers"
-    installer_path = download_resource('http://rubyforge.org/frs/download.php/76952/rubyinstaller-1.9.3-p429.exe')
+    installer_path = download_resource('http://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-1.9.3-p448.exe')
     FileUtils.cp installer_path, "installers/rubyinstaller.exe"
 
     variables = {


### PR DESCRIPTION
The rubyforge lnk is losted.
So, we have to use http://dl.bintray.com/ link if we can.
