### PR TITLE
Relax yajl-ruby gem version

### DIFF
--- a/td.gemspec
+++ b/td.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency "msgpack", [">= 0.4.4", "!= 0.5.0", "!= 0.5.1", "!= 0.5.2", "!= 0.5.3", "< 0.6.0"]
-  gem.add_dependency "yajl-ruby", "~> 1.1.0"
+  gem.add_dependency "yajl-ruby", "~> 1.1"
   gem.add_dependency "hirb", ">= 0.4.5"
   gem.add_dependency "parallel", "~> 0.6.1"
   gem.add_dependency "td-client", "~> 0.8.60"


### PR DESCRIPTION
yajl-ruby 1.2.0 is popular version so td command should allow this version.
It causes following warning in td-agent2:

``` sh
WARN: Unresolved specs during Gem::Specification.reset:
      yajl-ruby (~> 1.0)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
```
