### PR TITLE
msgpack.gz to CSV/TSV perf optimization

### DIFF
--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -384,13 +384,15 @@ module Command
             job.result_size, 0.1, 1)
         end
         job.result_each_with_compr_size {|row, compr_size|
-          indicator.update(compr_size) unless output.nil?
           # TODO limit the # of columns
           writer << row.map {|col|
             dump_column(col)
           }
           n_rows += 1
-          writer.flush if n_rows % 100 == 0 # flush every 100 recods
+          if n_rows % 100 == 0 # flush every 100 recods
+            writer.flush
+            indicator.update(compr_size) unless output.nil?
+          end
           break if output.nil? and !limit.nil? and n_rows == limit
         }
         indicator.finish unless output.nil?
@@ -415,17 +417,12 @@ module Command
             job.result_size, 0.1, 1)
         end
         job.result_each_with_compr_size {|row, compr_size|
-          indicator.update(compr_size) unless output.nil?
-          n_cols = 0
-          row.each {|col|
-            f.write "\t" if n_cols > 0
-            # TODO limit the # of columns
-            f.write dump_column(col)
-            n_cols += 1
-          }
-          f.write "\n"
+          f.write row.map {|col| dump_column(col)}.join("\t") + "\n"
           n_rows += 1
-          f.flush if n_rows % 100 == 0 # flush every 100 recods
+          if n_rows % 100 == 0
+            f.flush # flush every 100 recods
+            indicator.update(compr_size) unless output.nil?
+          end
           break if output.nil? and !limit.nil? and n_rows == limit
         }
         indicator.finish unless output.nil?
@@ -495,7 +492,7 @@ module Command
       job.result_each_with_compr_size {|row, compr_size|
         indicator.update(compr_size)
         rows << row.map {|v|
-          dump_column(v)
+          dump_column_safe_utf8(v)
         }
         n_rows += 1
         break if !limit.nil? and n_rows == limit
@@ -517,9 +514,11 @@ module Command
   end
 
   def dump_column(v)
-    require 'yajl'
+    v.is_a?(String) ? v.to_s : Yajl.dump(v)
+  end
 
-    s = v.is_a?(String) ? v.to_s : Yajl.dump(v)
+  def dump_column_safe_utf8(v)
+    s = dump_column(v)
     # Here does UTF-8 -> UTF-16LE -> UTF8 conversion:
     #   a) to make sure the string doesn't include invalid byte sequence
     #   b) to display multi-byte characters as it is

--- a/spec/td/command/job_spec.rb
+++ b/spec/td/command/job_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'td/command/common'
+require 'td/command/job'
+require 'td/command/list'
+require 'tempfile'
+
+module TreasureData::Command
+  describe 'job commands' do
+    let :command do
+      Class.new { include TreasureData::Command }.new
+    end
+
+    let :job do
+      job = TreasureData::Job.new(nil, 12345, 'hive', 'select * from employee')
+      job.instance_eval do
+        @result = [[["1", 2.0, {key:3}], 1], [["4", 5.0, {key:6}], 2], [["7", 8.0, {key:9}], 3]]
+        @result_size = 3
+        @status = 'success'
+      end
+      job
+    end
+
+    describe 'write_result' do
+      it 'supports json output' do
+        file = Tempfile.new("job_spec")
+        command.send(:show_result, job, file, nil, 'json')
+        File.read(file.path).should == %Q([["1",2.0,{"key":3}],\n["4",5.0,{"key":6}],\n["7",8.0,{"key":9}]])
+      end
+
+      it 'supports csv output' do
+        file = Tempfile.new("job_spec")
+        command.send(:show_result, job, file, nil, 'csv')
+        File.read(file.path).should == %Q(1,2.0,"{""key"":3}"\n4,5.0,"{""key"":6}"\n7,8.0,"{""key"":9}"\n)
+      end
+
+      it 'supports tsv output' do
+        file = Tempfile.new("job_spec")
+        command.send(:show_result, job, file, nil, 'tsv')
+        File.read(file.path).should == %Q(1\t2.0\t{"key":3}\n4\t5.0\t{"key":6}\n7\t8.0\t{"key":9}\n)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Skip encoding filter. As long as we write it to a file it's already
  UTF-8 and no need to filter wrong byte sequence
- Less calls of indicator#update
