### PR TITLE
Add MessagePackEOFError

### DIFF
--- a/lib/td/file_reader.rb
+++ b/lib/td/file_reader.rb
@@ -46,7 +46,7 @@ module TreasureData
       def forward
         content = @u.each {|r| break r }
         raise MessagePackEOFError unless content
-        return content
+        content
       end
     end
 

--- a/lib/td/file_reader.rb
+++ b/lib/td/file_reader.rb
@@ -9,7 +9,6 @@ module TreasureData
   # - when --columns a,b,c
   # ["v", 10, true] # array types
   # ...
-  class MessagePackEOFError < StandardError; end
   class FileReader
     require 'time'
     require 'zlib'
@@ -45,7 +44,7 @@ module TreasureData
 
       def forward
         content = @u.each {|r| break r }
-        raise MessagePackEOFError unless content
+        raise EOFError unless content
         content
       end
     end
@@ -501,7 +500,7 @@ module TreasureData
         while record = parser.forward
           block.call(record)
         end
-      rescue EOFError, MessagePackEOFError
+      rescue EOFError
       end
     end
 

--- a/lib/td/file_reader.rb
+++ b/lib/td/file_reader.rb
@@ -9,6 +9,7 @@ module TreasureData
   # - when --columns a,b,c
   # ["v", 10, true] # array types
   # ...
+  class MessagePackEOFError < StandardError; end
   class FileReader
     require 'time'
     require 'zlib'
@@ -43,7 +44,9 @@ module TreasureData
       end
 
       def forward
-        @u.each {|r| break r }
+        content = @u.each {|r| break r }
+        raise MessagePackEOFError unless content
+        return content
       end
     end
 
@@ -498,7 +501,7 @@ module TreasureData
         while record = parser.forward
           block.call(record)
         end
-      rescue EOFError
+      rescue EOFError, MessagePackEOFError
       end
     end
 


### PR DESCRIPTION
to raise it when MessagePackParsingReader forwards to end of io
and cannot read more, and rescue the exception in parsing.
Without this, in file_reader_spec.rb context 'msgpack' fails.

But I'm not sure that this PR satisfies td specification. Please give me your comments @frsyuki , @nahi .

fixed failures.
```
  1) TreasureData::FileReader parse msgpack it should behave like parse --time-value / --time-column cases parse msgpack with --time-value
     Failure/Error: reader.parse(io, error) { |record|
     NoMethodError:
       undefined method `[]=' for nil:NilClass
     Shared Example Group: "parse --time-value / --time-column cases" called from ./spec/file_reader_spec.rb:324
     # ./lib/td/file_reader.rb:295:in `forward'
     # ./lib/td/file_reader.rb:498:in `parse'
     # ./spec/file_reader_spec.rb:256:in `block (5 levels) in <top (required)>'
     # ./spec/file_reader_spec.rb:248:in `call'
     # ./spec/file_reader_spec.rb:248:in `parse_opt'
     # ./spec/file_reader_spec.rb:254:in `block (4 levels) in <top (required)>'

  2) TreasureData::FileReader parse msgpack it should behave like parse --time-value / --time-column cases parse msgpack with --time-column
     Failure/Error: reader.parse(io, error) { |record|
     NoMethodError:
       undefined method `[]' for nil:NilClass
     Shared Example Group: "parse --time-value / --time-column cases" called from ./spec/file_reader_spec.rb:324
     # ./lib/td/file_reader.rb:248:in `forward'
     # ./lib/td/file_reader.rb:498:in `parse'
     # ./spec/file_reader_spec.rb:266:in `block (5 levels) in <top (required)>'
     # ./spec/file_reader_spec.rb:248:in `call'
     # ./spec/file_reader_spec.rb:248:in `parse_opt'
     # ./spec/file_reader_spec.rb:264:in `block (4 levels) in <top (required)>'

  3) TreasureData::FileReader parse msgpack it should behave like parse --columns / --column-header cases array format with --column-columns it should behave like parse --time-value / --time-column cases parse msgpack with --time-value
     Failure/Error: reader.parse(io, error) { |record|
     NoMethodError:
       undefined method `each' for nil:NilClass
     Shared Example Group: "parse --time-value / --time-column cases" called from ./spec/file_reader_spec.rb:285
     # ./lib/td/file_reader.rb:230:in `zip'
     # ./lib/td/file_reader.rb:230:in `forward'
     # ./lib/td/file_reader.rb:294:in `forward'
     # ./lib/td/file_reader.rb:498:in `parse'
     # ./spec/file_reader_spec.rb:256:in `block (5 levels) in <top (required)>'
     # ./spec/file_reader_spec.rb:248:in `call'
     # ./spec/file_reader_spec.rb:248:in `parse_opt'
     # ./spec/file_reader_spec.rb:254:in `block (4 levels) in <top (required)>'

  4) TreasureData::FileReader parse msgpack it should behave like parse --columns / --column-header cases array format with --column-columns it should behave like parse --time-value / --time-column cases parse msgpack with --time-column
     Failure/Error: reader.parse(io, error) { |record|
     NoMethodError:
       undefined method `each' for nil:NilClass
     Shared Example Group: "parse --time-value / --time-column cases" called from ./spec/file_reader_spec.rb:285
     # ./lib/td/file_reader.rb:230:in `zip'
     # ./lib/td/file_reader.rb:230:in `forward'
     # ./lib/td/file_reader.rb:247:in `forward'
     # ./lib/td/file_reader.rb:498:in `parse'
     # ./spec/file_reader_spec.rb:266:in `block (5 levels) in <top (required)>'
     # ./spec/file_reader_spec.rb:248:in `call'
     # ./spec/file_reader_spec.rb:248:in `parse_opt'
     # ./spec/file_reader_spec.rb:264:in `block (4 levels) in <top (required)>'

  5) TreasureData::FileReader parse msgpack it should behave like parse --columns / --column-header cases array format with --column-header it should behave like parse --time-value / --time-column cases parse msgpack with --time-value
     Failure/Error: reader.parse(io, error) { |record|
     NoMethodError:
       undefined method `each' for nil:NilClass
     Shared Example Group: "parse --time-value / --time-column cases" called from ./spec/file_reader_spec.rb:293
     # ./lib/td/file_reader.rb:230:in `zip'
     # ./lib/td/file_reader.rb:230:in `forward'
     # ./lib/td/file_reader.rb:294:in `forward'
     # ./lib/td/file_reader.rb:498:in `parse'
     # ./spec/file_reader_spec.rb:256:in `block (5 levels) in <top (required)>'
     # ./spec/file_reader_spec.rb:248:in `call'
     # ./spec/file_reader_spec.rb:248:in `parse_opt'
     # ./spec/file_reader_spec.rb:254:in `block (4 levels) in <top (required)>'

  6) TreasureData::FileReader parse msgpack it should behave like parse --columns / --column-header cases array format with --column-header it should behave like parse --time-value / --time-column cases parse msgpack with --time-column
     Failure/Error: reader.parse(io, error) { |record|
     NoMethodError:
       undefined method `each' for nil:NilClass
     Shared Example Group: "parse --time-value / --time-column cases" called from ./spec/file_reader_spec.rb:293
     # ./lib/td/file_reader.rb:230:in `zip'
     # ./lib/td/file_reader.rb:230:in `forward'
     # ./lib/td/file_reader.rb:247:in `forward'
     # ./lib/td/file_reader.rb:498:in `parse'
     # ./spec/file_reader_spec.rb:266:in `block (5 levels) in <top (required)>'
     # ./spec/file_reader_spec.rb:248:in `call'
     # ./spec/file_reader_spec.rb:248:in `parse_opt'
     # ./spec/file_reader_spec.rb:264:in `block (4 levels) in <top (required)>'
```