### PR TITLE
Fix FileReader::LineReader encoding spec.

### DIFF
--- a/spec/file_reader/line_reader_spec.rb
+++ b/spec/file_reader/line_reader_spec.rb
@@ -33,21 +33,21 @@ describe FileReader::LineReader do
 
   it 'initialize with specifid encoding' do
     if io.respond_to?(:external_encoding)
-      ee = io.external_encoding
+      original_encoding = io.external_encoding
     end
 
     # when RUBY_VERSION >= 2.0, default encoding is utf-8.
-    # ensure that external_encoding is differ from the original external_encoding(ee).
-    if ee == Encoding.find('utf-8')
-      external_encoding = 'sjis'
+    # ensure that external_encoding is differ from the original external_encoding(original_encoding).
+    if original_encoding == Encoding.find('utf-8')
+      specified_encoding = 'sjis'
     else
-      external_encoding = 'utf-8'
+      specified_encoding = 'utf-8'
     end
 
-    FileReader::LineReader.new(io, error, {:encoding => external_encoding})
+    FileReader::LineReader.new(io, error, {:encoding => specified_encoding})
     if io.respond_to?(:external_encoding)
-      io.external_encoding.should_not == ee
-      io.external_encoding.should == Encoding.find(external_encoding)
+      io.external_encoding.should_not == original_encoding
+      io.external_encoding.should == Encoding.find(specified_encoding)
     end
   end
 

--- a/spec/file_reader/line_reader_spec.rb
+++ b/spec/file_reader/line_reader_spec.rb
@@ -35,10 +35,19 @@ describe FileReader::LineReader do
     if io.respond_to?(:external_encoding)
       ee = io.external_encoding
     end
-    FileReader::LineReader.new(io, error, {:encoding => 'utf-8'})
+
+    # when RUBY_VERSION >= 2.0, default encoding is utf-8.
+    # ensure that external_encoding is differ from the original external_encoding(ee).
+    if ee == Encoding.find('utf-8')
+      external_encoding = 'sjis'
+    else
+      external_encoding = 'utf-8'
+    end
+
+    FileReader::LineReader.new(io, error, {:encoding => external_encoding})
     if io.respond_to?(:external_encoding)
       io.external_encoding.should_not == ee
-      io.external_encoding.should == Encoding.find('utf-8')
+      io.external_encoding.should == Encoding.find(external_encoding)
     end
   end
 


### PR DESCRIPTION
Ensuring that external_encoding is differ from the original external_encoding,
the spec can check whether specified encoding will be applied to target io.

Before fixing, this spec failed only ruby ver. is 2.0+ (because default encoding became utf-8)

```
toriis-MacBook-Air:td toriiyuki$ rbenv local 2.2.0
toriis-MacBook-Air:td toriiyuki$ be rspec spec/file_reader/line_reader_spec.rb
.F....................

Failures:

  1) TreasureData::FileReader::LineReader initialize with specifid encoding
     Failure/Error: io.external_encoding.should_not == ee
       expected not: == #<Encoding:UTF-8>
                got:    #<Encoding:UTF-8>
       Diff:UTF-8.==(UTF-8) returned false even though the diff between UTF-8 and UTF-8 is empty. Check the implementation of UTF-8.==.
     # ./spec/file_reader/line_reader_spec.rb:40:in `block (2 levels) in <top (required)>'

Finished in 0.00845 seconds
22 examples, 1 failure
```