### PR TITLE
Add --null option to job:show command.

### DIFF
--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -143,7 +143,7 @@ module Command
       exclude = b
     }
 
-    op.on('-n [STRING]', '--null [STRING]', "null expression in csv or tsv (default: null)") {|s|
+    op.on('--null [STRING]', "null expression in csv or tsv (default: null)") {|s|
       expr = s || "null"
       render_opts[:null_expr] = expr.to_s
     }

--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -143,9 +143,8 @@ module Command
       exclude = b
     }
 
-    op.on('--null [STRING]', "null expression in csv or tsv (default: null)") {|s|
-      expr = s || "null"
-      render_opts[:null_expr] = expr.to_s
+    op.on('--null STRING', "null expression in csv or tsv") {|s|
+      render_opts[:null_expr] = s.to_s
     }
 
     job_id = op.cmd_parse

--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -143,8 +143,9 @@ module Command
       exclude = b
     }
 
-    op.on('-n STRING', '--null STRING', "null expression in csv or tsv (default: null)") {|s|
-      render_opts[:null_expr] = s.to_s
+    op.on('-n [STRING]', '--null [STRING]', "null expression in csv or tsv (default: null)") {|s|
+      expr = s || "null"
+      render_opts[:null_expr] = expr.to_s
     }
 
     job_id = op.cmd_parse

--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -143,6 +143,10 @@ module Command
       exclude = b
     }
 
+    op.on('-n', '--null', 'show null as blank in tsv/csv', TrueClass) { |b|
+      render_opts[:null_blank] = b
+    }
+
     job_id = op.cmd_parse
 
     # parameter concurrency validation
@@ -167,7 +171,6 @@ module Command
     end
 
     client = get_client
-
     job = client.job(job_id)
 
     puts "JobID       : #{job.job_id}"
@@ -387,7 +390,7 @@ module Command
         job.result_each_with_compr_size {|row, compr_size|
           # TODO limit the # of columns
           writer << row.map {|col|
-            dump_column(col)
+            dump_column(col, render_opts[:null_blank])
           }
           n_rows += 1
           if n_rows % 100 == 0 # flush every 100 recods
@@ -418,7 +421,7 @@ module Command
             job.result_size, 0.1, 1)
         end
         job.result_each_with_compr_size {|row, compr_size|
-          f.write row.map {|col| dump_column(col)}.join("\t") + "\n"
+          f.write row.map {|col| dump_column(col, render_opts[:null_blank])}.join("\t") + "\n"
           n_rows += 1
           if n_rows % 100 == 0
             f.flush # flush every 100 recods
@@ -493,7 +496,7 @@ module Command
       job.result_each_with_compr_size {|row, compr_size|
         indicator.update(compr_size)
         rows << row.map {|v|
-          dump_column_safe_utf8(v)
+          dump_column_safe_utf8(v, render_opts[:null_blank])
         }
         n_rows += 1
         break if !limit.nil? and n_rows == limit
@@ -514,15 +517,17 @@ module Command
     end
   end
 
-  def dump_column(v)
+  def dump_column(v, null_blank = false)
+    return nil if v.nil? && null_blank
+
     s = v.is_a?(String) ? v.to_s : Yajl.dump(v)
     # CAUTION: msgpack-ruby populates byte sequences as Encoding.default_internal which should be BINARY
     s = s.force_encoding('BINARY') if s.respond_to?(:encode)
     s
   end
 
-  def dump_column_safe_utf8(v)
-    s = dump_column(v)
+  def dump_column_safe_utf8(v, null_blank = false)
+    s = dump_column(v, null_blank)
     # Here does UTF-8 -> UTF-16LE -> UTF8 conversion:
     #   a) to make sure the string doesn't include invalid byte sequence
     #   b) to display multi-byte characters as it is

--- a/spec/td/command/job_spec.rb
+++ b/spec/td/command/job_spec.rb
@@ -163,12 +163,6 @@ module TreasureData::Command
           op = List::CommandParser.new("job:show", %w[job_id], %w[], nil, ["12345", "--null", '""'], true)
           command.job_show(op)
         end
-
-        it 'calls #show_result with null_expr option(only --null without string)' do
-          command.stub(:show_result).with(job, nil, nil, nil, {:header=>false, :null_expr=>'null'} )
-          op = List::CommandParser.new("job:show", %w[job_id], %w[], nil, ["12345", "--null"], true)
-          command.job_show(op)
-        end
       end
     end
 

--- a/spec/td/command/job_spec.rb
+++ b/spec/td/command/job_spec.rb
@@ -77,20 +77,20 @@ module TreasureData::Command
         context 'with --null option' do
           it 'dose not effect json output (nil will be shown as null)' do
             file = Tempfile.new("job_spec")
-            command.send(:show_result, job, file, nil, 'json', { null_blank: true })
+            command.send(:show_result, job, file, nil, 'json', { null_expr: "NULL" })
             File.read(file.path).should == %Q([[null,2.0,{"key":3}]])
           end
 
           it 'supports csv output' do
             file = Tempfile.new("job_spec")
-            command.send(:show_result, job, file, nil, 'csv', { null_blank: true })
-            File.read(file.path).should == %Q(,2.0,"{""key"":3}"\n)
+            command.send(:show_result, job, file, nil, 'csv', { null_expr: "NULL" })
+            File.read(file.path).should == %Q(NULL,2.0,"{""key"":3}"\n)
           end
 
           it 'supports tsv output' do
             file = Tempfile.new("job_spec")
-            command.send(:show_result, job, file, nil, 'tsv', { null_blank: true })
-            File.read(file.path).should == %Q(\t2.0\t{"key":3}\n)
+            command.send(:show_result, job, file, nil, 'tsv', { null_expr: "\"\"" })
+            File.read(file.path).should == %Q(""\t2.0\t{"key":3}\n)
           end
         end
       end
@@ -136,7 +136,7 @@ module TreasureData::Command
       end
 
       context 'without --null option' do
-        it 'calls #show_result without null_blank option' do
+        it 'calls #show_result without null_expr option' do
           command.stub(:show_result).with(job, nil, nil, nil, {:header=>false})
           op = List::CommandParser.new("job:show", %w[job_id], %w[], nil, ["12345"], true)
           command.job_show(op)
@@ -144,9 +144,15 @@ module TreasureData::Command
       end
 
       context 'with --null option' do
-        it 'calls #show_result with null_blank option' do
-          command.stub(:show_result).with(job, nil, nil, nil, {:header=>false, :null_blank=>true} )
-          op = List::CommandParser.new("job:show", %w[job_id], %w[], nil, ["12345", "--null"], true)
+        it 'calls #show_result with null_expr option' do
+          command.stub(:show_result).with(job, nil, nil, nil, {:header=>false, :null_expr=>"NULL"} )
+          op = List::CommandParser.new("job:show", %w[job_id], %w[], nil, ["12345", "--null", "NULL"], true)
+          command.job_show(op)
+        end
+
+        it 'calls #show_result with null_expr option' do
+          command.stub(:show_result).with(job, nil, nil, nil, {:header=>false, :null_expr=>'""'} )
+          op = List::CommandParser.new("job:show", %w[job_id], %w[], nil, ["12345", "--null", '""'], true)
           command.job_show(op)
         end
       end

--- a/spec/td/command/job_spec.rb
+++ b/spec/td/command/job_spec.rb
@@ -81,10 +81,26 @@ module TreasureData::Command
             File.read(file.path).should == %Q([[null,2.0,{"key":3}]])
           end
 
-          it 'supports csv output' do
-            file = Tempfile.new("job_spec")
-            command.send(:show_result, job, file, nil, 'csv', { null_expr: "NULL" })
-            File.read(file.path).should == %Q(NULL,2.0,"{""key"":3}"\n)
+          context 'csv format' do
+            let(:file) { Tempfile.new("job_spec") }
+
+            context 'specified string is NULL' do
+              let!(:null_expr) { "NULL" }
+
+              it 'shows nill as specified string' do
+                command.send(:show_result, job, file, nil, 'csv', { null_expr: null_expr })
+                File.read(file.path).should == %Q(NULL,2.0,"{""key"":3}"\n)
+              end
+            end
+
+            context 'specified string is empty string' do
+              let!(:null_expr) { '' }
+
+              it 'shows nill as empty string' do
+                command.send(:show_result, job, file, nil, 'csv', { null_expr: null_expr })
+                File.read(file.path).should == %Q("",2.0,"{""key"":3}"\n)
+              end
+            end
           end
 
           it 'supports tsv output' do

--- a/spec/td/command/job_spec.rb
+++ b/spec/td/command/job_spec.rb
@@ -13,6 +13,8 @@ module TreasureData::Command
     end
 
     describe 'write_result' do
+      let(:file) { Tempfile.new("job_spec") }
+
       context 'result without nil' do
         let :job do
           job = TreasureData::Job.new(nil, 12345, 'hive', 'select * from employee')
@@ -25,19 +27,16 @@ module TreasureData::Command
         end
 
         it 'supports json output' do
-          file = Tempfile.new("job_spec")
           command.send(:show_result, job, file, nil, 'json')
           File.read(file.path).should == %Q([["1",2.0,{"key":3}],\n["4",5.0,{"key":6}],\n["7",8.0,{"key":9}]])
         end
 
         it 'supports csv output' do
-          file = Tempfile.new("job_spec")
           command.send(:show_result, job, file, nil, 'csv')
           File.read(file.path).should == %Q(1,2.0,"{""key"":3}"\n4,5.0,"{""key"":6}"\n7,8.0,"{""key"":9}"\n)
         end
 
         it 'supports tsv output' do
-          file = Tempfile.new("job_spec")
           command.send(:show_result, job, file, nil, 'tsv')
           File.read(file.path).should == %Q(1\t2.0\t{"key":3}\n4\t5.0\t{"key":6}\n7\t8.0\t{"key":9}\n)
         end
@@ -56,19 +55,16 @@ module TreasureData::Command
 
         context 'without --null option' do
           it 'supports json output' do
-            file = Tempfile.new("job_spec")
             command.send(:show_result, job, file, nil, 'json')
             File.read(file.path).should == %Q([[null,2.0,{"key":3}]])
           end
 
           it 'supports csv output' do
-            file = Tempfile.new("job_spec")
             command.send(:show_result, job, file, nil, 'csv')
             File.read(file.path).should == %Q(null,2.0,"{""key"":3}"\n)
           end
 
           it 'supports tsv output' do
-            file = Tempfile.new("job_spec")
             command.send(:show_result, job, file, nil, 'tsv')
             File.read(file.path).should == %Q(null\t2.0\t{"key":3}\n)
           end
@@ -76,14 +72,11 @@ module TreasureData::Command
 
         context 'with --null option' do
           it 'dose not effect json output (nil will be shown as null)' do
-            file = Tempfile.new("job_spec")
             command.send(:show_result, job, file, nil, 'json', { null_expr: "NULL" })
             File.read(file.path).should == %Q([[null,2.0,{"key":3}]])
           end
 
           context 'csv format' do
-            let(:file) { Tempfile.new("job_spec") }
-
             context 'specified string is NULL' do
               let!(:null_expr) { "NULL" }
 
@@ -104,7 +97,6 @@ module TreasureData::Command
           end
 
           it 'supports tsv output' do
-            file = Tempfile.new("job_spec")
             command.send(:show_result, job, file, nil, 'tsv', { null_expr: "\"\"" })
             File.read(file.path).should == %Q(""\t2.0\t{"key":3}\n)
           end

--- a/spec/td/command/job_spec.rb
+++ b/spec/td/command/job_spec.rb
@@ -163,6 +163,12 @@ module TreasureData::Command
           op = List::CommandParser.new("job:show", %w[job_id], %w[], nil, ["12345", "--null", '""'], true)
           command.job_show(op)
         end
+
+        it 'calls #show_result with null_expr option(only --null without string)' do
+          command.stub(:show_result).with(job, nil, nil, nil, {:header=>false, :null_expr=>'null'} )
+          op = List::CommandParser.new("job:show", %w[job_id], %w[], nil, ["12345", "--null"], true)
+          command.job_show(op)
+        end
       end
     end
 

--- a/spec/td/command/job_spec.rb
+++ b/spec/td/command/job_spec.rb
@@ -13,32 +13,142 @@ module TreasureData::Command
     end
 
     describe 'write_result' do
-      let :job do
-        job = TreasureData::Job.new(nil, 12345, 'hive', 'select * from employee')
-        job.instance_eval do
-          @result = [[["1", 2.0, {key:3}], 1], [["4", 5.0, {key:6}], 2], [["7", 8.0, {key:9}], 3]]
-          @result_size = 3
-          @status = 'success'
+      context 'result without nil' do
+        let :job do
+          job = TreasureData::Job.new(nil, 12345, 'hive', 'select * from employee')
+          job.instance_eval do
+            @result = [[["1", 2.0, {key:3}], 1], [["4", 5.0, {key:6}], 2], [["7", 8.0, {key:9}], 3]]
+            @result_size = 3
+            @status = 'success'
+          end
+          job
         end
-        job
+
+        it 'supports json output' do
+          file = Tempfile.new("job_spec")
+          command.send(:show_result, job, file, nil, 'json')
+          File.read(file.path).should == %Q([["1",2.0,{"key":3}],\n["4",5.0,{"key":6}],\n["7",8.0,{"key":9}]])
+        end
+
+        it 'supports csv output' do
+          file = Tempfile.new("job_spec")
+          command.send(:show_result, job, file, nil, 'csv')
+          File.read(file.path).should == %Q(1,2.0,"{""key"":3}"\n4,5.0,"{""key"":6}"\n7,8.0,"{""key"":9}"\n)
+        end
+
+        it 'supports tsv output' do
+          file = Tempfile.new("job_spec")
+          command.send(:show_result, job, file, nil, 'tsv')
+          File.read(file.path).should == %Q(1\t2.0\t{"key":3}\n4\t5.0\t{"key":6}\n7\t8.0\t{"key":9}\n)
+        end
       end
 
-      it 'supports json output' do
-        file = Tempfile.new("job_spec")
-        command.send(:show_result, job, file, nil, 'json')
-        File.read(file.path).should == %Q([["1",2.0,{"key":3}],\n["4",5.0,{"key":6}],\n["7",8.0,{"key":9}]])
+      context 'result with nil' do
+        let :job do
+          job = TreasureData::Job.new(nil, 12345, 'hive', 'select * from employee')
+          job.instance_eval do
+            @result = [[[nil, 2.0, {key:3}], 1]]
+            @result_size = 3
+            @status = 'success'
+          end
+          job
+        end
+
+        context 'without --null option' do
+          it 'supports json output' do
+            file = Tempfile.new("job_spec")
+            command.send(:show_result, job, file, nil, 'json')
+            File.read(file.path).should == %Q([[null,2.0,{"key":3}]])
+          end
+
+          it 'supports csv output' do
+            file = Tempfile.new("job_spec")
+            command.send(:show_result, job, file, nil, 'csv')
+            File.read(file.path).should == %Q(null,2.0,"{""key"":3}"\n)
+          end
+
+          it 'supports tsv output' do
+            file = Tempfile.new("job_spec")
+            command.send(:show_result, job, file, nil, 'tsv')
+            File.read(file.path).should == %Q(null\t2.0\t{"key":3}\n)
+          end
+        end
+
+        context 'with --null option' do
+          it 'dose not effect json output (nil will be shown as null)' do
+            file = Tempfile.new("job_spec")
+            command.send(:show_result, job, file, nil, 'json', { null_blank: true })
+            File.read(file.path).should == %Q([[null,2.0,{"key":3}]])
+          end
+
+          it 'supports csv output' do
+            file = Tempfile.new("job_spec")
+            command.send(:show_result, job, file, nil, 'csv', { null_blank: true })
+            File.read(file.path).should == %Q(,2.0,"{""key"":3}"\n)
+          end
+
+          it 'supports tsv output' do
+            file = Tempfile.new("job_spec")
+            command.send(:show_result, job, file, nil, 'tsv', { null_blank: true })
+            File.read(file.path).should == %Q(\t2.0\t{"key":3}\n)
+          end
+        end
+      end
+    end
+
+    describe '#job_show' do
+      let(:job_id) { "12345" }
+
+      let :job_classs do
+        Struct.new(:job_id,
+                   :status,
+                   :type,
+                   :db_name,
+                   :priority,
+                   :retry_limit,
+                   :result_url,
+                   :query,
+                   :cpu_time,
+                   :result_size
+                  )
       end
 
-      it 'supports csv output' do
-        file = Tempfile.new("job_spec")
-        command.send(:show_result, job, file, nil, 'csv')
-        File.read(file.path).should == %Q(1,2.0,"{""key"":3}"\n4,5.0,"{""key"":6}"\n7,8.0,"{""key"":9}"\n)
+      let :job do
+        job_classs.new(job_id,
+                       nil,
+                       :hive,
+                       "db_name",
+                       1,
+                       1,
+                       "test_url",
+                       "test_qury",
+                       1,
+                       3
+                      )
       end
 
-      it 'supports tsv output' do
-        file = Tempfile.new("job_spec")
-        command.send(:show_result, job, file, nil, 'tsv')
-        File.read(file.path).should == %Q(1\t2.0\t{"key":3}\n4\t5.0\t{"key":6}\n7\t8.0\t{"key":9}\n)
+      before do
+        job.stub(:finished?).and_return(true)
+
+        client = Object.new
+        client.stub(:job).with(job_id).and_return(job)
+        command.stub(:get_client).and_return(client)
+      end
+
+      context 'without --null option' do
+        it 'calls #show_result without null_blank option' do
+          command.stub(:show_result).with(job, nil, nil, nil, {:header=>false})
+          op = List::CommandParser.new("job:show", %w[job_id], %w[], nil, ["12345"], true)
+          command.job_show(op)
+        end
+      end
+
+      context 'with --null option' do
+        it 'calls #show_result with null_blank option' do
+          command.stub(:show_result).with(job, nil, nil, nil, {:header=>false, :null_blank=>true} )
+          op = List::CommandParser.new("job:show", %w[job_id], %w[], nil, ["12345", "--null"], true)
+          command.job_show(op)
+        end
       end
     end
 


### PR DESCRIPTION
this option enables to show null value as specified string in csv and tsv format.

ex.
```
 td job:show 12345 --null  STRING
```

Please check it @nahi san.