### PR TITLE
Add sched:result command

### DIFF
--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -102,7 +102,16 @@ module Command
   end
 
   def job_show(op)
-    op, verbose, wait, output, format, render_opts, limit, exclude = job_show_options(op)
+    options = job_show_options(op)
+
+    op          = options[:op]
+    verbose     = options[:verbose]
+    wait        = options[:wait]
+    output      = options[:output]
+    format      = options[:format]
+    render_opts = options[:render_opts]
+    limit       = options[:limit]
+    exclude     = options[:exclude]
 
     job_id = op.cmd_parse
 

--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -1,5 +1,8 @@
+require 'td/command/options'
+
 module TreasureData
 module Command
+  include Options
 
   # TODO
   JOB_WAIT_MAX_RETRY_COUNT_ON_NETWORK_ERROR = 10
@@ -49,6 +52,7 @@ module Command
     op.on('--slow [SECONDS]', 'show slow queries (default threshold: 3600 seconds)', Integer) {|i|
       slower_than = i || 3600
     }
+
     set_render_format_option(op)
 
     max = op.cmd_parse
@@ -98,57 +102,9 @@ module Command
   end
 
   def job_show(op)
-    verbose = nil
-    wait = false
-    output = nil
-    format = nil
-    render_opts = {:header => false}
-    limit = nil
-    exclude = false
-
-    op.on('-v', '--verbose', 'show logs', TrueClass) {|b|
-      verbose = b
-    }
-    op.on('-w', '--wait', 'wait for finishing the job', TrueClass) {|b|
-      wait = b
-    }
-    op.on('-G', '--vertical', 'use vertical table to show results', TrueClass) {|b|
-      render_opts[:vertical] = b
-    }
-    op.on('-o', '--output PATH', 'write result to the file') {|s|
-      unless Dir.exist?(File.dirname(s))
-        s = File.expand_path(s)
-      end
-      output = s
-      format = 'tsv' if format.nil?
-    }
-    op.on('-f', '--format FORMAT', 'format of the result to write to the file (tsv, csv, json, msgpack, and msgpack.gz)') {|s|
-      unless ['tsv', 'csv', 'json', 'msgpack', 'msgpack.gz'].include?(s)
-        raise "Unknown format #{s.dump}. Supported formats are: tsv, csv, json, msgpack, and msgpack.gz"
-      end
-      format = s
-    }
-    op.on('-l', '--limit ROWS', 'limit the number of result rows shown when not outputting to file') {|s|
-      unless s.to_i > 0
-        raise "Invalid limit number. Must be a positive integer"
-      end
-      limit = s.to_i
-    }
-    op.on('-c', '--column-header', 'output of the columns\' header when the schema is available',
-                                   '  for the table (only applies to tsv and csv formats)', TrueClass) {|b|
-      render_opts[:header] = b;
-    }
-    op.on('-x', '--exclude', 'do not automatically retrieve the job result', TrueClass) {|b|
-      exclude = b
-    }
-
-    op.on('--null STRING', "null expression in csv or tsv") {|s|
-      render_opts[:null_expr] = s.to_s
-    }
+    op, verbose, wait, output, format, render_opts, limit, exclude = job_show_options(op)
 
     job_id = op.cmd_parse
-
-    # parameter concurrency validation
 
     if output.nil? && format
       unless ['tsv', 'csv', 'json'].include?(format)

--- a/lib/td/command/list.rb
+++ b/lib/td/command/list.rb
@@ -289,9 +289,6 @@ module List
   add_list 'sched:update', %w[name], 'Modify a schedule', ['sched:update sched1 -s "0 */2 * * *" -d my_db -t "Asia/Tokyo" -D 3600']
   add_list 'sched:history', %w[name max?], 'Show history of scheduled queries', ['sched sched1 --page 1']
   add_list 'sched:run', %w[name time], 'Run scheduled queries for the specified time', ['sched:run sched1 "2013-01-01 00:00:00" -n 6']
-  add_list 'sched:last_job', %w[name], "Show status and result of the last job ran\n" +
-                                      "The options are identical to those of the 'job:show' command.",
-                                       ['sched:last_job sched1']
   add_list 'sched:result', %w[name], "Show status and result of the last job ran.\n" +
                                  "--last [N] option enables to show the result before N from the last.\n" +
                                  "The other options are identical to those of the 'job:show' command.",

--- a/lib/td/command/list.rb
+++ b/lib/td/command/list.rb
@@ -15,7 +15,7 @@ module List
       @cmd_requires_connectivity = req_conn
     end
 
-    attr_accessor :message, :name, :cmd_requires_connectivity
+    attr_accessor :message, :name, :cmd_requires_connectivity, :argv
 
     def on(*argv)
       @has_options = true
@@ -118,7 +118,15 @@ module List
 
     def usage
       compile!
-      "%-40s   # %s" % [@usage_args, @description]
+      description_lines = @description.split("\n")
+      strout = "%-40s   # %s" % [@usage_args, description_lines[0]]
+      if description_lines.length > 1
+        description_lines[1..-1].each {|lines|
+          strout += "\n"
+          strout += "%-40s     # %s" % ["", lines]
+        }
+      end
+      strout
     end
 
     def group
@@ -281,6 +289,9 @@ module List
   add_list 'sched:update', %w[name], 'Modify a schedule', ['sched:update sched1 -s "0 */2 * * *" -d my_db -t "Asia/Tokyo" -D 3600']
   add_list 'sched:history', %w[name max?], 'Show history of scheduled queries', ['sched sched1 --page 1']
   add_list 'sched:run', %w[name time], 'Run scheduled queries for the specified time', ['sched:run sched1 "2013-01-01 00:00:00" -n 6']
+  add_list 'sched:last_job', %w[name], "Show status and result of the last job ran\n" +
+                                       "The options are identical to those of the 'job:show' command.",
+                                        ['sched:last_job sched1']
 
   add_list 'query', %w[sql?], 'Issue a query', ['query -d example_db -w -r rset1 "select count(*) from table1"',
                                                'query -d example_db -w -r rset1 -q query.txt']

--- a/lib/td/command/list.rb
+++ b/lib/td/command/list.rb
@@ -355,6 +355,7 @@ module List
   add_alias 'schedule:create', 'sched:create'
   add_alias 'schedule:delete', 'sched:delete'
   add_alias 'schedule:history', 'sched:history'
+  add_alias 'schedule:result', 'sched:result'
   add_alias 'schedule:hist', 'sched:history'
   add_alias 'sched:hist', 'sched:history'
   add_alias 'sched', 'sched:history'

--- a/lib/td/command/list.rb
+++ b/lib/td/command/list.rb
@@ -290,8 +290,12 @@ module List
   add_list 'sched:history', %w[name max?], 'Show history of scheduled queries', ['sched sched1 --page 1']
   add_list 'sched:run', %w[name time], 'Run scheduled queries for the specified time', ['sched:run sched1 "2013-01-01 00:00:00" -n 6']
   add_list 'sched:last_job', %w[name], "Show status and result of the last job ran\n" +
-                                       "The options are identical to those of the 'job:show' command.",
-                                        ['sched:last_job sched1']
+                                      "The options are identical to those of the 'job:show' command.",
+                                       ['sched:last_job sched1']
+  add_list 'sched:result', %w[name], "Show status and result of the last job ran.\n" +
+                                 "--last [N] option enables to show the result before N from the last.\n" +
+                                 "The other options are identical to those of the 'job:show' command.",
+                                 ['sched:result NAME | sched:result NAME --last | sched:result NAME --last 3']
 
   add_list 'query', %w[sql?], 'Issue a query', ['query -d example_db -w -r rset1 "select count(*) from table1"',
                                                'query -d example_db -w -r rset1 -q query.txt']

--- a/lib/td/command/options.rb
+++ b/lib/td/command/options.rb
@@ -1,0 +1,59 @@
+module TreasureData
+module Command
+module Options
+
+  def job_show_options(op)
+    verbose = nil
+    wait = false
+    output = nil
+    format = nil
+    render_opts = {:header => false}
+    limit = nil
+    exclude = false
+
+    op.on('-v', '--verbose', 'show logs', TrueClass) {|b|
+      verbose = b
+    }
+    op.on('-w', '--wait', 'wait for finishing the job', TrueClass) {|b|
+      wait = b
+    }
+    op.on('-G', '--vertical', 'use vertical table to show results', TrueClass) {|b|
+      render_opts[:vertical] = b
+    }
+    op.on('-o', '--output PATH', 'write result to the file') {|s|
+      unless Dir.exist?(File.dirname(s))
+        s = File.expand_path(s)
+      end
+      output = s
+      format = 'tsv' if format.nil?
+    }
+    op.on('-f', '--format FORMAT', 'format of the result to write to the file (tsv, csv, json, msgpack, and msgpack.gz)') {|s|
+      unless ['tsv', 'csv', 'json', 'msgpack', 'msgpack.gz'].include?(s)
+        raise "Unknown format #{s.dump}. Supported formats are: tsv, csv, json, msgpack, and msgpack.gz"
+      end
+      format = s
+    }
+    op.on('-l', '--limit ROWS', 'limit the number of result rows shown when not outputting to file') {|s|
+      unless s.to_i > 0
+        raise "Invalid limit number. Must be a positive integer"
+      end
+      limit = s.to_i
+    }
+    op.on('-c', '--column-header', 'output of the columns\' header when the schema is available',
+                                   '  for the table (only applies to tsv and csv formats)', TrueClass) {|b|
+      render_opts[:header] = b;
+    }
+    op.on('-x', '--exclude', 'do not automatically retrieve the job result', TrueClass) {|b|
+      exclude = b
+    }
+
+    op.on('--null STRING', "null expression in csv or tsv") {|s|
+      render_opts[:null_expr] = s.to_s
+    }
+
+    [op,verbose, wait, output, format, render_opts, limit, exclude]
+  end
+
+end # module Options
+end # module Command
+end # module TrasureData

--- a/lib/td/command/options.rb
+++ b/lib/td/command/options.rb
@@ -56,4 +56,4 @@ module Options
 
 end # module Options
 end # module Command
-end # module TrasureData
+end # module TreasureData

--- a/lib/td/command/options.rb
+++ b/lib/td/command/options.rb
@@ -51,7 +51,16 @@ module Options
       render_opts[:null_expr] = s.to_s
     }
 
-    [op,verbose, wait, output, format, render_opts, limit, exclude]
+    {
+      :op          => op,
+      :verbose     => verbose,
+      :wait        => wait,
+      :output      => output,
+      :format      => format,
+      :render_opts => render_opts,
+      :limit       => limit,
+      :exclude     => exclude,
+    }
   end
 
 end # module Options

--- a/lib/td/command/sched.rb
+++ b/lib/td/command/sched.rb
@@ -359,7 +359,7 @@ module Command
 
     # build the job:show command now
     argv = job_show_option_argv(argv_saved, name, back_number)
-    argv << job.job_id.to_s
+    argv << job.job_id
 
     Runner.new.run(argv)
   end

--- a/lib/td/command/sched.rb
+++ b/lib/td/command/sched.rb
@@ -353,7 +353,7 @@ module Command
     job = history.first
 
     if job.nil?
-      puts "No jobs available for this query. Refer to 'sched:history'."
+      $stderr.puts "No jobs available for this query. Refer to 'sched:history'."
       exit 1
     end
 

--- a/lib/td/command/sched.rb
+++ b/lib/td/command/sched.rb
@@ -327,7 +327,16 @@ module Command
   end
 
   def sched_result(op)
-    op, verbose, wait, output, format, render_opts, limit, exclude = job_show_options(op)
+    options = job_show_options(op)
+
+    op          = options[:op]
+    verbose     = options[:verbose]
+    wait        = options[:wait]
+    output      = options[:output]
+    format      = options[:format]
+    render_opts = options[:render_opts]
+    limit       = options[:limit]
+    exclude     = options[:exclude]
 
     back_number = 1
     op.on('--last [Number]', "show the result before N from the last. default: 1") do |n|

--- a/lib/td/command/sched.rb
+++ b/lib/td/command/sched.rb
@@ -339,8 +339,8 @@ module Command
     exclude     = options[:exclude]
 
     back_number = 1
-    op.on('--last [Number]', "show the result before N from the last. default: 1") do |n|
-      back_number = n ?  n.to_i : 1
+    op.on('--last [Number]', Integer, "show the result before N from the last. default: 1") do |n|
+      back_number = n ?  n : 1
     end
 
     # save argv before calling cmd_parse, which removes flags from the argv array
@@ -368,21 +368,23 @@ module Command
     argv = ['job:show']
     argv += (argv_saved - [name]) if argv_saved.length > 0
 
-    index_of_last = argv.index("--last")
-
-    return argv unless index_of_last
-
-    # the arg value following to "--last"
-    index_of_next_of_last = index_of_last + 1
-    next_of_last = argv[index_of_next_of_last]
-
-    indexes_of_options_for_sched_result = [index_of_last]
     # there are three argvs parters for sched_result.
     # 1. without --last
     # 2. --last (without Num)
     # 3. --last Num
     # 'back_number' is value of Num which was parsed by OptionParser.
     # remove both "--last" and Num if they are.
+
+    index_of_last = argv.index("--last")
+
+    return argv unless index_of_last
+
+    index_of_next_of_last = index_of_last + 1
+
+    # the arg value following to "--last"
+    next_of_last = argv[index_of_next_of_last]
+
+    indexes_of_options_for_sched_result = [index_of_last]
     indexes_of_options_for_sched_result << index_of_next_of_last if next_of_last == back_number.to_s
 
     indexes_of_options_for_sched_result.each do |index|

--- a/lib/td/command/sched.rb
+++ b/lib/td/command/sched.rb
@@ -342,7 +342,7 @@ module Command
     }
 
     # save argv before calling cmd_parse, which removes flags from the argv array
-    argv_saved = op.argv[0..-2]
+    argv_saved = op.argv.dup
 
     name = op.cmd_parse
 
@@ -365,7 +365,7 @@ module Command
 
     # build the job:show command now
     argv = ['job:show']
-    argv += argv_saved if argv_saved.length > 0
+    argv += (argv_saved - [name]) if argv_saved.length > 0
     argv << job_id.to_s
 
     Runner.new.run(argv)

--- a/lib/td/command/sched.rb
+++ b/lib/td/command/sched.rb
@@ -326,48 +326,6 @@ module Command
     puts cmd_render_table(rows, :fields => [:JobID, :Time], :max_width=>500, :render_format => op.render_format)
   end
 
-  def sched_last_job(op)
-    op.on('-v', '--verbose', 'show logs', TrueClass) {}
-    op.on('-w', '--wait', 'wait for finishing the job', TrueClass) {|b|
-    }
-    op.on('-G', '--vertical', 'use vertical table to show results', TrueClass) {|b|
-    }
-    op.on('-o', '--output PATH', 'write result to the file') {|s|
-    }
-    op.on('-f', '--format FORMAT', 'format of the result to write to the file (tsv, csv, json, msgpack, and msgpack.gz)') {|s|
-    }
-    op.on('-l', '--limit ROWS', 'limit the number of result rows shown when not outputting to file') {|s|
-    }
-    op.on('-c', '--column-header', 'output of the columns\' header when the schema is available',
-                                   '  for the table (only applies to tsv and csv formats)', TrueClass) {|b|
-    }
-    op.on('-x', '--exclude', 'do not automatically retrieve the job result', TrueClass) {|b|
-    }
-
-    # save argv before calling cmd_parse, which removes flags from the argv array
-    argv_saved = op.argv.dup
-
-    name = op.cmd_parse
-
-    # fetch the last job ID
-    client = get_client
-    history = get_history(client, name)
-
-    job = history.first
-    if job.nil?
-      puts "No jobs available for this query. Refer to 'sched:history'."
-      exit 1
-    end
-    job_id = job.job_id
-
-    # build the job:show command now
-    argv = ['job:show']
-    argv += (argv_saved - [name]) if argv_saved.length > 0
-    argv << job_id.to_s
-
-    Runner.new.run(argv)
-  end
-
   def sched_result(op)
     op, verbose, wait, output, format, render_opts, limit, exclude = job_show_options(op)
 

--- a/lib/td/command/sched.rb
+++ b/lib/td/command/sched.rb
@@ -348,10 +348,9 @@ module Command
     name = op.cmd_parse
 
     client = get_client
-    history = get_history(client, name)
+    history = get_history(client, name, (back_number - 1), back_number)
 
-    # when arg is --last 1, meaning 'the last job history', you should get history[0]
-    job = history[back_number - 1]
+    job = history.first
 
     if job.nil?
       puts "No jobs available for this query. Refer to 'sched:history'."
@@ -377,22 +376,23 @@ module Command
     next_of_last = argv[index_of_last + 1]
 
     options_for_sched_result = ["--last"]
-    # remove both "--last" and back_number if they were.
+    # remove both "--last" and back_number if they are.
     options_for_sched_result << next_of_last if next_of_last == back_number.to_s
     argv = argv - options_for_sched_result
 
     argv
   end
 
-  def get_history(client, name)
+  def get_history(client, name, from, to)
     begin
-      history = client.history(name, 0, 1)
+      history = client.history(name, from, to)
     rescue NotFoundError
       cmd_debug_error $!
       $stderr.puts "Schedule '#{name}' does not exist."
       $stderr.puts "Use '#{$prog} " + Config.cl_options_string + "sched:list' to show list of the schedules."
       exit 1
     end
+
     history
   end
 

--- a/lib/td/command/sched.rb
+++ b/lib/td/command/sched.rb
@@ -373,14 +373,23 @@ module Command
     return argv unless index_of_last
 
     # the arg value following to "--last"
-    next_of_last = argv[index_of_last + 1]
+    index_of_next_of_last = index_of_last + 1
+    next_of_last = argv[index_of_next_of_last]
 
-    options_for_sched_result = ["--last"]
-    # remove both "--last" and back_number if they are.
-    options_for_sched_result << next_of_last if next_of_last == back_number.to_s
-    argv = argv - options_for_sched_result
+    indexes_of_options_for_sched_result = [index_of_last]
+    # there are three argvs parters for sched_result.
+    # 1. without --last
+    # 2. --last (without Num)
+    # 3. --last Num
+    # 'back_number' is value of Num which was parsed by OptionParser.
+    # remove both "--last" and Num if they are.
+    indexes_of_options_for_sched_result << index_of_next_of_last if next_of_last == back_number.to_s
 
-    argv
+    indexes_of_options_for_sched_result.each do |index|
+      argv[index] = nil
+    end
+
+    argv.compact
   end
 
   def get_history(client, name, from, to)

--- a/lib/td/command/sched.rb
+++ b/lib/td/command/sched.rb
@@ -323,5 +323,78 @@ module Command
     puts cmd_render_table(rows, :fields => [:JobID, :Time], :max_width=>500, :render_format => op.render_format)
   end
 
+  def old_sched_last_job(op)
+    # require 'td/command/job'  # job_priority_name_of
+    require 'td/command/runner'
+
+    name = op.argv.last
+
+    client = get_client
+
+    begin
+      history = client.history(name, 0, 1)
+    rescue NotFoundError
+      cmd_debug_error $!
+      $stderr.puts "Schedule '#{name}' does not exist."
+      $stderr.puts "Use '#{$prog} " + Config.cl_options_string + "sched:list' to show list of the schedules."
+      exit 1
+    end
+
+    job_id = history.first.job_id
+
+    # build the job:show command now
+    argv = ['job:show']
+    argv += op.argv[0..-2] if op.argv.length > 1
+    argv << job_id.to_s
+    Runner.new.run(argv)
+  end
+
+  def sched_last_job(op)
+    op.on('-v', '--verbose', 'show logs', TrueClass) {}
+    op.on('-w', '--wait', 'wait for finishing the job', TrueClass) {|b|
+    }
+    op.on('-G', '--vertical', 'use vertical table to show results', TrueClass) {|b|
+    }
+    op.on('-o', '--output PATH', 'write result to the file') {|s|
+    }
+    op.on('-f', '--format FORMAT', 'format of the result to write to the file (tsv, csv, json, msgpack, and msgpack.gz)') {|s|
+    }
+    op.on('-l', '--limit ROWS', 'limit the number of result rows shown when not outputting to file') {|s|
+    }
+    op.on('-c', '--column-header', 'output of the columns\' header when the schema is available',
+                                   '  for the table (only applies to tsv and csv formats)', TrueClass) {|b|
+    }
+    op.on('-x', '--exclude', 'do not automatically retrieve the job result', TrueClass) {|b|
+    }
+
+    # save argv before calling cmd_parse, which removes flags from the argv array
+    argv_saved = op.argv[0..-2]
+
+    name = op.cmd_parse
+
+    # fetch the last job ID
+    client = get_client
+    begin
+      history = client.history(name, 0, 1)
+    rescue NotFoundError
+      cmd_debug_error $!
+      $stderr.puts "Schedule '#{name}' does not exist."
+      $stderr.puts "Use '#{$prog} " + Config.cl_options_string + "sched:list' to show list of the schedules."
+      exit 1
+    end
+    job = history.first
+    if job.nil?
+      puts "No jobs available for this query. Refer to 'sched:history'."
+      exit 1
+    end
+    job_id = job.job_id
+
+    # build the job:show command now
+    argv = ['job:show']
+    argv += argv_saved if argv_saved.length > 0
+    argv << job_id.to_s
+    Runner.new.run(argv)
+  end
+
 end # module Command
 end # module TreasureData

--- a/lib/td/command/sched.rb
+++ b/lib/td/command/sched.rb
@@ -323,32 +323,6 @@ module Command
     puts cmd_render_table(rows, :fields => [:JobID, :Time], :max_width=>500, :render_format => op.render_format)
   end
 
-  def old_sched_last_job(op)
-    # require 'td/command/job'  # job_priority_name_of
-    require 'td/command/runner'
-
-    name = op.argv.last
-
-    client = get_client
-
-    begin
-      history = client.history(name, 0, 1)
-    rescue NotFoundError
-      cmd_debug_error $!
-      $stderr.puts "Schedule '#{name}' does not exist."
-      $stderr.puts "Use '#{$prog} " + Config.cl_options_string + "sched:list' to show list of the schedules."
-      exit 1
-    end
-
-    job_id = history.first.job_id
-
-    # build the job:show command now
-    argv = ['job:show']
-    argv += op.argv[0..-2] if op.argv.length > 1
-    argv << job_id.to_s
-    Runner.new.run(argv)
-  end
-
   def sched_last_job(op)
     op.on('-v', '--verbose', 'show logs', TrueClass) {}
     op.on('-w', '--wait', 'wait for finishing the job', TrueClass) {|b|
@@ -393,6 +367,7 @@ module Command
     argv = ['job:show']
     argv += argv_saved if argv_saved.length > 0
     argv << job_id.to_s
+
     Runner.new.run(argv)
   end
 

--- a/spec/td/command/sched_spec.rb
+++ b/spec/td/command/sched_spec.rb
@@ -115,6 +115,21 @@ module TreasureData::Command
             }.to raise_exception, "No jobs available for this query. Refer to 'sched:history'"
           end
         end
+
+        context '--last WRONGARG(not a number)' do
+          let(:history) { [job1] }
+          let(:back_number) { 1 }
+
+          let(:argv) { %w(--last TEST --format csv) }
+
+          it "exit with 1" do
+            begin
+              command.sched_result(op)
+            rescue SystemExit => e
+              expect(e.status).to eq 1
+            end
+          end
+        end
       end
 
       context "history dose not exists" do

--- a/spec/td/command/sched_spec.rb
+++ b/spec/td/command/sched_spec.rb
@@ -19,14 +19,17 @@ module TreasureData::Command
     let(:time) { Time.now.xmlschema }
     let(:command) { Class.new { include TreasureData::Command }.new }
     let(:argv) { [] }
+    let(:schedules) { [] }
     let(:op) { List::CommandParser.new('sched:last_job', %w[], %w[], false, argv, []) }
 
+    before do
+      client.stub(:schedules).and_return(schedules)
+      client.stub(:history).and_return(history)
+      command.stub(:get_client).and_return(client)
+    end
+
     describe 'sched_history' do
-      before do
-        client.stub(:schedules).and_return([])
-        client.stub(:history).and_return([job1, job2])
-        command.stub(:get_client).and_return(client)
-      end
+      let(:history) { [job1, job2] }
 
       it 'runs' do
         expect {
@@ -37,12 +40,6 @@ module TreasureData::Command
 
     describe "sched_last_job" do
       let(:history) { [job1, job2] }
-
-      before do
-        command.stub(:get_client).and_return(client)
-        command.stub(:get_database) # don't raise NotFoundError
-        client.stub(:history).and_return(history)
-      end
 
       subject { command.sched_last_job(op) }
 
@@ -91,14 +88,68 @@ module TreasureData::Command
     end
 
     describe 'sched_result' do
-      let(:history) { [job1, job2] }
+      subject { command.sched_result(op) }
 
-      before do
-        command.stub(:get_client).and_return(client)
-        command.stub(:get_database) # don't raise NotFoundError
-        client.stub(:history).and_return(history)
+      shared_examples_for("passing argv and job_id to job:show") do
+        it "invoke 'job:show [original argv] [job id]'" do
+          TreasureData::Command::Runner.any_instance.should_receive(:run).with(["job:show", *show_arg, job_id])
+          subject
+        end
       end
 
+      context "history exists" do
+        let(:history) { [job1, job2] }
+
+        context 'without --last option' do
+          let(:argv) { %w(--last --format csv) }
+          let(:show_arg) { %w(--format csv) }
+          let(:job_id) { history.first.job_id }
+          it_behaves_like "passing argv and job_id to job:show"
+        end
+
+        context '--last witout Num' do
+          let(:argv) { %w(--last --format csv) }
+          let(:show_arg) { %w(--format csv) }
+          let(:job_id) { history.first.job_id }
+          it_behaves_like "passing argv and job_id to job:show"
+        end
+
+        context '--last 1' do
+          let(:argv) { %w(--last 1 --format csv) }
+          let(:show_arg) { %w(--format csv) }
+          let(:job_id) { history.first.job_id }
+          it_behaves_like "passing argv and job_id to job:show"
+        end
+
+        context '--last 2 after format option' do
+          let(:argv) { %w(--format csv --last 2 ) }
+          let(:show_arg) { %w(--format csv) }
+          let(:job_id) { history[1].job_id }
+          it_behaves_like "passing argv and job_id to job:show"
+        end
+
+        context '--last 3(too back over)' do
+          let(:argv) { %w(--last 3 --format csv) }
+          it 'raise ' do
+            expect {
+              command.sched_result(op)
+            }.to raise_exception, "No jobs available for this query. Refer to 'sched:history'"
+          end
+        end
+      end
+
+      context "history dose not exists" do
+        let(:history) { [] }
+        before { client.stub(:history) { raise TreasureData::NotFoundError } }
+
+        it "exit with 1" do
+          begin
+            subject
+          rescue SystemExit => e
+            expect(e.status).to eq 1
+          end
+        end
+      end
     end
   end
 end

--- a/spec/td/command/sched_spec.rb
+++ b/spec/td/command/sched_spec.rb
@@ -7,84 +7,98 @@ require 'td/client/model'
 require 'time'
 
 module TreasureData::Command
+  describe TreasureData::Command do
+    let(:client) { Object.new }
 
-  describe 'sched_history' do
-    it 'runs' do
-      client = Object.new
-      time = Time.now.xmlschema
-      job_params = ['job_id', :type, 'query', 'status', nil, nil, time, time, 123, 456]
-      job1 = TreasureData::ScheduledJob.new(client, '2015-02-17 13:22:52 +0900', *job_params)
-      job2 = TreasureData::ScheduledJob.new(client, nil, *job_params)
-      client.stub(:schedules).and_return([])
-      client.stub(:history).and_return([job1, job2])
-      command = Class.new { include TreasureData::Command }.new
-      command.stub(:get_client).and_return(client)
-      op = List::CommandParser.new('sched:history', %w[], %w[], false, [], [])
-      expect {
-        command.sched_history(op)
-      }.to_not raise_exception
+    let :job_params do
+      ['job_id', :type, 'query', 'status', nil, nil, time, time, 123, 456]
     end
-  end
 
-  describe "sched_last_job" do
-    let(:job_params) { ['job_id', :type, 'query', 'status', nil, nil, Time.now.xmlschema, Time.now.xmlschema, 123, 456] }
     let(:job1) { TreasureData::ScheduledJob.new(client, '2015-02-17 13:22:52 +0900', *job_params) }
     let(:job2) { TreasureData::ScheduledJob.new(client, nil, *job_params) }
-    let(:history) { [job1, job2] }
-    let(:client) { Object.new }
+    let(:time) { Time.now.xmlschema }
     let(:command) { Class.new { include TreasureData::Command }.new }
     let(:argv) { [] }
     let(:op) { List::CommandParser.new('sched:last_job', %w[], %w[], false, argv, []) }
 
-    before do
-      command.stub(:get_client).and_return(client)
-      command.stub(:get_database) # don't raise NotFoundError
-      client.stub(:history).and_return(history)
-    end
-
-    subject { command.sched_last_job(op) }
-
-    describe "invoke job:show" do
-      shared_examples_for("passing argv to job:show") do
-        it "invoke 'job:show [original argv] [first job id]'" do
-          TreasureData::Command::Runner.any_instance.should_receive(:run).with(["job:show", *argv, history.first.job_id])
-          subject
-        end
+    describe 'sched_history' do
+      before do
+        client.stub(:schedules).and_return([])
+        client.stub(:history).and_return([job1, job2])
+        command.stub(:get_client).and_return(client)
       end
 
-      context "argv is empty" do
-        let(:argv) { [] }
-        it_behaves_like "passing argv to job:show"
-      end
-
-      context "argv is present" do
-        let(:argv) { %w(-v -l 2 --format csv) }
-        it_behaves_like "passing argv to job:show"
+      it 'runs' do
+        expect {
+          command.sched_history(op)
+        }.to_not raise_exception
       end
     end
 
-    context "database is not found" do
-      before { client.stub(:history) { raise TreasureData::NotFoundError } }
+    describe "sched_last_job" do
+      let(:history) { [job1, job2] }
 
-      it "exit with 1" do
-        begin
-          subject
-        rescue SystemExit => e
-          expect(e.status).to eq 1
+      before do
+        command.stub(:get_client).and_return(client)
+        command.stub(:get_database) # don't raise NotFoundError
+        client.stub(:history).and_return(history)
+      end
+
+      subject { command.sched_last_job(op) }
+
+      describe "invoke job:show" do
+        shared_examples_for("passing argv to job:show") do
+          it "invoke 'job:show [original argv] [first job id]'" do
+            TreasureData::Command::Runner.any_instance.should_receive(:run).with(["job:show", *argv, history.first.job_id])
+            subject
+          end
+        end
+
+        context "argv is empty" do
+          let(:argv) { [] }
+          it_behaves_like "passing argv to job:show"
+        end
+
+        context "argv is present" do
+          let(:argv) { %w(-v -l 2 --format csv) }
+          it_behaves_like "passing argv to job:show"
+        end
+      end
+
+      context "database is not found" do
+        before { client.stub(:history) { raise TreasureData::NotFoundError } }
+
+        it "exit with 1" do
+          begin
+            subject
+          rescue SystemExit => e
+            expect(e.status).to eq 1
+          end
+        end
+      end
+
+      context "history is empty" do
+        let(:history) { [] }
+
+        it "exit with 1" do
+          begin
+            subject
+          rescue SystemExit => e
+            expect(e.status).to eq 1
+          end
         end
       end
     end
 
-    context "history is empty" do
-      let(:history) { [] }
+    describe 'sched_result' do
+      let(:history) { [job1, job2] }
 
-      it "exit with 1" do
-        begin
-          subject
-        rescue SystemExit => e
-          expect(e.status).to eq 1
-        end
+      before do
+        command.stub(:get_client).and_return(client)
+        command.stub(:get_database) # don't raise NotFoundError
+        client.stub(:history).and_return(history)
       end
+
     end
   end
 end

--- a/spec/td/command/sched_spec.rb
+++ b/spec/td/command/sched_spec.rb
@@ -86,6 +86,15 @@ module TreasureData::Command
           it_behaves_like "passing argv and job_id to job:show"
         end
 
+        context '--last 1 and --limit 1' do
+          let(:history) { [job1] }
+          let(:back_number) { 1 }
+
+          let(:argv) { %w(--last 1 --format csv --limit 1) }
+          let(:show_arg) { %w(--format csv --limit 1) }
+          it_behaves_like "passing argv and job_id to job:show"
+        end
+
         context '--last 2 after format option' do
           let(:history) { [job2] }
           let(:back_number) { 2 }

--- a/spec/td/command/sched_spec.rb
+++ b/spec/td/command/sched_spec.rb
@@ -25,4 +25,66 @@ module TreasureData::Command
       }.to_not raise_exception
     end
   end
+
+  describe "sched_last_job" do
+    let(:job_params) { ['job_id', :type, 'query', 'status', nil, nil, Time.now.xmlschema, Time.now.xmlschema, 123, 456] }
+    let(:job1) { TreasureData::ScheduledJob.new(client, '2015-02-17 13:22:52 +0900', *job_params) }
+    let(:job2) { TreasureData::ScheduledJob.new(client, nil, *job_params) }
+    let(:history) { [job1, job2] }
+    let(:client) { Object.new }
+    let(:command) { Class.new { include TreasureData::Command }.new }
+    let(:argv) { [] }
+    let(:op) { List::CommandParser.new('sched:last_job', %w[], %w[], false, argv, []) }
+
+    before do
+      command.stub(:get_client).and_return(client)
+      command.stub(:get_database) # don't raise NotFoundError
+      client.stub(:history).and_return(history)
+    end
+
+    subject { command.sched_last_job(op) }
+
+    describe "invoke job:show" do
+      shared_examples_for("passing argv to job:show") do
+        it "invoke 'job:show [original argv] [first job id]'" do
+          TreasureData::Command::Runner.any_instance.should_receive(:run).with(["job:show", *argv, history.first.job_id])
+          subject
+        end
+      end
+
+      context "argv is empty" do
+        let(:argv) { [] }
+        it_behaves_like "passing argv to job:show"
+      end
+
+      context "argv is present" do
+        let(:argv) { %w(-v -l 2 --format csv) }
+        it_behaves_like "passing argv to job:show"
+      end
+    end
+
+    context "database is not found" do
+      before { client.stub(:history) { raise TreasureData::NotFoundError } }
+
+      it "exit with 1" do
+        begin
+          subject
+        rescue SystemExit => e
+          expect(e.status).to eq 1
+        end
+      end
+    end
+
+    context "history is empty" do
+      let(:history) { [] }
+
+      it "exit with 1" do
+        begin
+          subject
+        rescue SystemExit => e
+          expect(e.status).to eq 1
+        end
+      end
+    end
+  end
 end

--- a/spec/td/command/sched_spec.rb
+++ b/spec/td/command/sched_spec.rb
@@ -38,55 +38,6 @@ module TreasureData::Command
       end
     end
 
-    describe "sched_last_job" do
-      let(:history) { [job1, job2] }
-
-      subject { command.sched_last_job(op) }
-
-      describe "invoke job:show" do
-        shared_examples_for("passing argv to job:show") do
-          it "invoke 'job:show [original argv] [first job id]'" do
-            TreasureData::Command::Runner.any_instance.should_receive(:run).with(["job:show", *argv, history.first.job_id])
-            subject
-          end
-        end
-
-        context "argv is empty" do
-          let(:argv) { [] }
-          it_behaves_like "passing argv to job:show"
-        end
-
-        context "argv is present" do
-          let(:argv) { %w(-v -l 2 --format csv) }
-          it_behaves_like "passing argv to job:show"
-        end
-      end
-
-      context "database is not found" do
-        before { client.stub(:history) { raise TreasureData::NotFoundError } }
-
-        it "exit with 1" do
-          begin
-            subject
-          rescue SystemExit => e
-            expect(e.status).to eq 1
-          end
-        end
-      end
-
-      context "history is empty" do
-        let(:history) { [] }
-
-        it "exit with 1" do
-          begin
-            subject
-          rescue SystemExit => e
-            expect(e.status).to eq 1
-          end
-        end
-      end
-    end
-
     describe 'sched_result' do
       subject { command.sched_result(op) }
 


### PR DESCRIPTION
usage

```
% td sched:result <name> --last 1 -o output_file.csv -f csv
```

It shows `job:show` result without job_id, only by the num from the latest job.
`--last N` enables to specify  the num.

- --last => show the latest job result
- --last 2 => 2nd latest
- --last 3 => 3rd...
