### PR TITLE
Fix #47 save as temporary file in downloading progress

### DIFF
--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -478,8 +478,7 @@ module Command
     end
 
     if tempfile && File.exists?(tempfile)
-      File.open(output, "wb"){|f| f.write(File.read(tempfile)) }
-      File.unlink(tempfile)
+      FileUtils.mv(tempfile, output.respond_to?(:path) ? output.path : output)
     end
   end
 

--- a/spec/td/command/job_spec.rb
+++ b/spec/td/command/job_spec.rb
@@ -28,44 +28,42 @@ module TreasureData::Command
 
       describe "using tempfile" do
         let(:tempfile) { "#{file.path}.tmp" }
-        let(:content) { "dummy\ncontent" }
 
         before do
-          File.should_receive(:read).with(tempfile).and_return { content }
-          File.should_receive(:unlink).with(tempfile)
+          file.truncate(0)
           command.send(:show_result, job, file, nil, format)
         end
 
-        subject { file.read }
+        subject { file.size }
 
         context "format: json" do
           let(:format) { "json" }
 
-          it { should == content }
+          it { should >= 0 }
         end
 
         context "format: csv" do
           let(:format) { "csv" }
 
-          it { should == content }
+          it { should >= 0 }
         end
 
         context "format: tsv" do
           let(:format) { "tsv" }
 
-          it { should == content }
+          it { should >= 0 }
         end
 
         context "format: msgpack" do
           let(:format) { "msgpack" }
 
-          it { should == content }
+          it { should >= 0 }
         end
 
         context "format: msgpack.gz" do
           let(:format) { "msgpack.gz" }
 
-          it { should == content }
+          it { should >= 0 }
         end
       end
 

--- a/spec/td/command/job_spec.rb
+++ b/spec/td/command/job_spec.rb
@@ -29,41 +29,71 @@ module TreasureData::Command
       describe "using tempfile" do
         let(:tempfile) { "#{file.path}.tmp" }
 
-        before do
-          file.truncate(0)
-          command.send(:show_result, job, file, nil, format)
-        end
-
-        subject { file.size }
+        subject { command.send(:show_result, job, file, nil, format) }
 
         context "format: json" do
           let(:format) { "json" }
 
-          it { should >= 0 }
+          it do
+            FileUtils.should_receive(:mv).with(tempfile, file.path)
+            subject
+          end
+          it do
+            command.should_receive(:open_file).with(tempfile, "w")
+            subject
+          end
         end
 
         context "format: csv" do
           let(:format) { "csv" }
 
-          it { should >= 0 }
+          it do
+            FileUtils.should_receive(:mv).with(tempfile, file.path)
+            subject
+          end
+          it do
+            command.should_receive(:open_file).with(tempfile, "w")
+            subject
+          end
         end
 
         context "format: tsv" do
           let(:format) { "tsv" }
 
-          it { should >= 0 }
+          it do
+            FileUtils.should_receive(:mv).with(tempfile, file.path)
+            subject
+          end
+          it do
+            command.should_receive(:open_file).with(tempfile, "w")
+            subject
+          end
         end
 
         context "format: msgpack" do
           let(:format) { "msgpack" }
 
-          it { should >= 0 }
+          it do
+            FileUtils.should_receive(:mv).with(tempfile, file.path)
+            subject
+          end
+          it do
+            command.should_receive(:open_file).with(tempfile, "wb")
+            subject
+          end
         end
 
         context "format: msgpack.gz" do
           let(:format) { "msgpack.gz" }
 
-          it { should >= 0 }
+          it do
+            FileUtils.should_receive(:mv).with(tempfile, file.path)
+            subject
+          end
+          it do
+            command.should_receive(:open_file).with(tempfile, "wb")
+            subject
+          end
         end
       end
 

--- a/spec/td/command/job_spec.rb
+++ b/spec/td/command/job_spec.rb
@@ -22,7 +22,51 @@ module TreasureData::Command
           @result_size = 3
           @status = 'success'
         end
+        job.stub(:result_format) # for msgpack, msgpack.gz
         job
+      end
+
+      describe "using tempfile" do
+        let(:tempfile) { "#{file.path}.tmp" }
+        let(:content) { "dummy\ncontent" }
+
+        before do
+          File.should_receive(:read).with(tempfile).and_return { content }
+          File.should_receive(:unlink).with(tempfile)
+          command.send(:show_result, job, file, nil, format)
+        end
+
+        subject { file.read }
+
+        context "format: json" do
+          let(:format) { "json" }
+
+          it { should == content }
+        end
+
+        context "format: csv" do
+          let(:format) { "csv" }
+
+          it { should == content }
+        end
+
+        context "format: tsv" do
+          let(:format) { "tsv" }
+
+          it { should == content }
+        end
+
+        context "format: msgpack" do
+          let(:format) { "msgpack" }
+
+          it { should == content }
+        end
+
+        context "format: msgpack.gz" do
+          let(:format) { "msgpack.gz" }
+
+          it { should == content }
+        end
       end
 
       context 'result without nil' do


### PR DESCRIPTION
Fix #47 
`write_result` method will be called by `job:show` and `query` sub command.