### PR TITLE
removing useless tab for tsv at the end of line of header

### DIFF
--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -394,10 +394,7 @@ private
       open_file(output, "w") {|f|
         # output headers
         if render_opts[:header] && job.hive_result_schema
-          job.hive_result_schema.each {|name,type|
-            f.write name + "\t"
-          }
-          f.write "\n"
+          f.write job.hive_result_schema.map {|col| col.first}.join("\t") + "\n"
         end
         # output data
         n_rows = 0


### PR DESCRIPTION
I found a problem on exporting result as tsv format with column-header.

```
$ td job:show <jobid> -f tsv -o ./result.tsv --column-header
```


### before

tab is unnecessary at the end of line.

```
name<tab>count<tab>
abc<tab>123
def<tab>456
```

### after

I have fixed the behavior.

```
name<tab>count
abc<tab>123
def<tab>456
```


