### PR TITLE
Show job duration by job list

### DIFF
--- a/lib/td/command/common.rb
+++ b/lib/td/command/common.rb
@@ -2,6 +2,8 @@ require 'td/version'
 
 module TreasureData
 
+require "td/config"
+
 autoload :API, 'td/client/api'
 autoload :Client, 'td/client'
 autoload :Database, 'td/client'

--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -86,12 +86,13 @@ module Command
         :CPUTime => cpu_time.rjust(17),
         :ResultSize => (job.result_size ? Command.humanize_bytesize(job.result_size, 2) : ""),
         :Priority => priority,
-        :Result => job.result_url
+        :Result => job.result_url,
+        :Duration => Time.at(job.duration).utc.strftime("%X")
       }
     }
 
     puts cmd_render_table(rows,
-      :fields => [:JobID, :Status, :Start, :Elapsed, :CPUTime, :ResultSize, :Priority, :Result, :Type, :Database, :Query],
+      :fields => [:JobID, :Status, :Start, :Elapsed, :CPUTime, :ResultSize, :Priority, :Result, :Type, :Database, :Query, :Duration],
       :max_width => 1000,
       :render_format => op.render_format
     )


### PR DESCRIPTION
This PR supports to show `job#duration` by `td job:list` command. This PR needs https://github.com/treasure-data/td-client-ruby/pull/43, so before this PR is merged, `td-client-ruby#43` should be merged and released.