### PR TITLE
Use fully quallified output methods such as $stdout.puts instead puts

### DIFF
--- a/lib/td/command/account.rb
+++ b/lib/td/command/account.rb
@@ -44,7 +44,7 @@ module Command
     puts "Enter your Treasure Data credentials."
     unless user_name
       begin
-        print "Email: "
+        $stdout.print "Email: "
         line = STDIN.gets || ""
         user_name = line.strip
       rescue Interrupt
@@ -62,14 +62,14 @@ module Command
 
     3.times do
       begin
-        print "Password (typing will be hidden): "
+        $stdout.print "Password (typing will be hidden): "
         password = get_password
       rescue Interrupt
         $stderr.print "\ncanceled."
         exit 1
       ensure
         system "stty echo"   # TODO termios
-        print "\n"
+        $stdout.print "\n"
       end
 
       if password.empty?

--- a/lib/td/command/account.rb
+++ b/lib/td/command/account.rb
@@ -41,7 +41,7 @@ module Command
       end
     end
 
-    puts "Enter your Treasure Data credentials."
+    $stdout.puts "Enter your Treasure Data credentials."
     unless user_name
       begin
         $stdout.print "Email: "
@@ -91,7 +91,7 @@ module Command
     end
     return unless client
 
-    puts "Authenticated successfully."
+    $stdout.puts "Authenticated successfully."
 
     conf ||= Config.new
     conf["account.user"] = user_name

--- a/lib/td/command/acl.rb
+++ b/lib/td/command/acl.rb
@@ -14,7 +14,7 @@ module Command
       rows << {:Subject => ac.subject, :Action => ac.action, :Scope => ac.scope, :"Grant option" => ac.grant_option}
     }
 
-    puts cmd_render_table(rows, :fields => [:Subject, :Action, :Scope, :"Grant option"])
+    $stdout.puts cmd_render_table(rows, :fields => [:Subject, :Action, :Scope, :"Grant option"])
 
     if rows.empty?
       $stderr.puts "There are no access controls."

--- a/lib/td/command/apikey.rb
+++ b/lib/td/command/apikey.rb
@@ -4,7 +4,7 @@ module Command
 
   def apikey_show(op)
     if Config.apikey
-      puts Config.apikey
+      $stdout.puts Config.apikey
       return
     end
 
@@ -20,7 +20,7 @@ module Command
       exit 1
     end
 
-    puts conf['account.apikey']
+    $stdout.puts conf['account.apikey']
   end
 
   def apikey_set(op)
@@ -55,8 +55,8 @@ module Command
     conf["account.apikey"] = apikey
     conf.save
 
-    puts "API key is set."
-    puts "Use '#{$prog} db:create <db_name>' to create a database."
+    $stdout.puts "API key is set."
+    $stdout.puts "Use '#{$prog} db:create <db_name>' to create a database."
   end
 
 end

--- a/lib/td/command/bulk_import.rb
+++ b/lib/td/command/bulk_import.rb
@@ -16,7 +16,7 @@ module Command
       rows << {:Name=>bi.name, :Table=>"#{bi.database}.#{bi.table}", :Status=>bi.status.to_s.capitalize, :Frozen=>bi.upload_frozen? ? 'Frozen' : '', :JobID=>bi.job_id, :"Valid Parts"=>bi.valid_parts, :"Error Parts"=>bi.error_parts, :"Valid Records"=>bi.valid_records, :"Error Records"=>bi.error_records}
     }
 
-    puts cmd_render_table(rows, :fields => [:Name, :Table, :Status, :Frozen, :JobID, :"Valid Parts", :"Error Parts", :"Valid Records", :"Error Records"], :max_width=>200, :render_format => op.render_format)
+    $stdout.puts cmd_render_table(rows, :fields => [:Name, :Table, :Status, :Frozen, :JobID, :"Valid Parts", :"Error Parts", :"Valid Records", :"Error Records"], :max_width=>200, :render_format => op.render_format)
 
     if rows.empty?
       $stderr.puts "There are no bulk import sessions."
@@ -75,7 +75,7 @@ module Command
 
     list = client.list_bulk_import_parts(name)
     list.each {|name|
-      puts "  #{name}"
+      $stdout.puts "  #{name}"
     }
   end
 
@@ -185,7 +185,7 @@ module Command
   end
 
   def bulk_import_upload_parts2(op)
-    puts "This command is moved to 'td import:upload' since 0.10.85."
+    $stdout.puts "This command is moved to 'td import:upload' since 0.10.85."
   end
 
   # obsoleted
@@ -338,7 +338,7 @@ module Command
 
     require 'yajl'
     client.bulk_import_error_records(name) {|r|
-      puts Yajl.dump(r)
+      $stdout.puts Yajl.dump(r)
     }
   end
 
@@ -459,7 +459,7 @@ module Command
   end
 
   def bulk_import_prepare_parts2(op)
-    puts "This command is moved to 'td import:prepare' since 0.10.85."
+    $stdout.puts "This command is moved to 'td import:prepare' since 0.10.85."
   end
 
   private

--- a/lib/td/command/common.rb
+++ b/lib/td/command/common.rb
@@ -249,7 +249,7 @@ EOS
     3.times do
       begin
         system "stty -echo"  # TODO termios
-        print "Password (typing will be hidden): "
+        $stdout.print "Password (typing will be hidden): "
         password = STDIN.gets || ""
         password = password[0..-2]  # strip \n
       rescue Interrupt
@@ -257,7 +257,7 @@ EOS
         exit 1
       ensure
         system "stty echo"   # TODO termios
-        print "\n"
+        $stdout.print "\n"
       end
 
       if password.empty?
@@ -328,7 +328,7 @@ EOS
   class DownloadProgressIndicator
     def initialize(msg)
       @base_msg = msg
-      print @base_msg + " " * 10
+      $stdout.print @base_msg + " " * 10
     end
   end
 
@@ -343,8 +343,8 @@ EOS
     def update
       if (time = Time.now.to_i) - @last_time >= @periodicity
         msg = "\r#{@base_msg}: #{Command.humanize_elapsed_time(@start_time, time)} elapsed"
-        print "\r" + " " * (msg.length + 10)
-        print msg
+        $stdout.print "\r" + " " * (msg.length + 10)
+        $stdout.print msg
         @last_time = time
         true
       else
@@ -378,15 +378,15 @@ EOS
     def update(curr_size)
       if @size.nil? || @size == 0
         msg = "\r#{@base_msg}: #{Command.humanize_bytesize(curr_size)}"
-        print msg
+        $stdout.print msg
         true
       else
         ratio = (curr_size.to_f * 100 / @size).round(1)
         if ratio >= (@last_perc_step + @perc_step) &&
            (!@min_periodicity || (time = Time.now.to_i) - @last_time >= @min_periodicity)
           msg = "\r#{@base_msg}: #{Command.humanize_bytesize(curr_size)} / #{ratio}%"
-          print "\r" + " " * (msg.length + 10)
-          print msg
+          $stdout.print "\r" + " " * (msg.length + 10)
+          $stdout.print msg
           @last_perc_step = ratio
           @last_time = time
           true
@@ -397,7 +397,7 @@ EOS
     end
 
     def finish
-      print "\r#{@base_msg}...done" + " " * 20
+      $stdout.print "\r#{@base_msg}...done" + " " * 20
     end
   end
 

--- a/lib/td/command/common.rb
+++ b/lib/td/command/common.rb
@@ -353,7 +353,7 @@ EOS
     end
 
     def finish
-      puts "\r#{@base_msg}...done" + " " * 20
+      $stdout.puts "\r#{@base_msg}...done" + " " * 20
     end
   end
 

--- a/lib/td/command/connector.rb
+++ b/lib/td/command/connector.rb
@@ -65,8 +65,8 @@ module Command
       f << config_str
     end
 
-    puts "Created #{out} file."
-    puts "Use '#{$prog} " + Config.cl_options_string + "connector:preview #{out}' to see bulk load preview."
+    $stdout.puts "Created #{out} file."
+    $stdout.puts "Use '#{$prog} " + Config.cl_options_string + "connector:preview #{out}' to see bulk load preview."
   end
 
   def connector_preview(op)
@@ -89,10 +89,10 @@ module Command
       cols
     } 
 
-    puts cmd_render_table(rows, :fields => fields, :render_format => op.render_format)
+    $stdout.puts cmd_render_table(rows, :fields => fields, :render_format => op.render_format)
 
-    puts "Update #{config_file} and use '#{$prog} " + Config.cl_options_string + "connector:preview #{config_file}' to preview again."
-    puts "Use '#{$prog} " + Config.cl_options_string + "connector:issue #{config_file}' to run Server-side bulk load."
+    $stdout.puts "Update #{config_file} and use '#{$prog} " + Config.cl_options_string + "connector:preview #{config_file}' to preview again."
+    $stdout.puts "Use '#{$prog} " + Config.cl_options_string + "connector:issue #{config_file}' to run Server-side bulk load."
   end
 
   def connector_issue(op)
@@ -116,8 +116,8 @@ module Command
     client = get_client()
     job_id = client.bulk_load_issue(database, table, job)
 
-    puts "Job #{job_id} is queued."
-    puts "Use '#{$prog} " + Config.cl_options_string + "job:show #{job_id}' to show the status."
+    $stdout.puts "Job #{job_id} is queued."
+    $stdout.puts "Use '#{$prog} " + Config.cl_options_string + "job:show #{job_id}' to show the status."
 
     if wait
       wait_connector_job(client, job_id, exclude)
@@ -138,7 +138,7 @@ module Command
       Hash[fields.zip(e.to_h.values_at(*keys))]
     }
 
-    puts cmd_render_table(rows, :fields => fields, :render_format => op.render_format)
+    $stdout.puts cmd_render_table(rows, :fields => fields, :render_format => op.render_format)
   end
 
   def connector_create(op)
@@ -195,8 +195,8 @@ module Command
 
     client = get_client()
     session = client.bulk_load_delete(name)
-    puts 'Deleted session'
-    puts '--'
+    $stdout.puts 'Deleted session'
+    $stdout.puts '--'
     dump_connector_session(session)
   end
 
@@ -219,7 +219,7 @@ module Command
         :Duration => (e.end_at.nil? ? Time.now.to_i : e.end_at) - e.start_at,
       }
     }
-    puts cmd_render_table(rows, :fields => fields, :render_format => op.render_format)
+    $stdout.puts cmd_render_table(rows, :fields => fields, :render_format => op.render_format)
   end
 
   def connector_run(op)
@@ -231,8 +231,8 @@ module Command
 
     client = get_client()
     job_id = client.bulk_load_run(name)
-    puts "Job #{job_id} is queued."
-    puts "Use '#{$prog} " + Config.cl_options_string + "job:show #{job_id}' to show the status."
+    $stdout.puts "Job #{job_id} is queued."
+    $stdout.puts "Use '#{$prog} " + Config.cl_options_string + "job:show #{job_id}' to show the status."
 
     if wait
       wait_connector_job(client, job_id, exclude)
@@ -279,20 +279,20 @@ private
   end
 
   def dump_connector_session(session)
-    puts "Name     : #{session.name}"
-    puts "Cron     : #{session.cron}"
-    puts "Timezone : #{session.timezone}"
-    puts "Delay    : #{session.delay}"
-    puts "Database : #{session.database}"
-    puts "Table    : #{session.table}"
-    puts "Config"
-    puts YAML.dump(session.config.to_h)
+    $stdout.puts "Name     : #{session.name}"
+    $stdout.puts "Cron     : #{session.cron}"
+    $stdout.puts "Timezone : #{session.timezone}"
+    $stdout.puts "Delay    : #{session.delay}"
+    $stdout.puts "Database : #{session.database}"
+    $stdout.puts "Table    : #{session.table}"
+    $stdout.puts "Config"
+    $stdout.puts YAML.dump(session.config.to_h)
   end
 
   def wait_connector_job(client, job_id, exclude)
     job = client.job(job_id)
     wait_job(job, true)
-    puts "Status     : #{job.status}"
+    $stdout.puts "Status     : #{job.status}"
   end
 
 end

--- a/lib/td/command/db.rb
+++ b/lib/td/command/db.rb
@@ -22,7 +22,7 @@ module Command
       [map[:Type].size, map[:Table]]
     }
 
-    puts cmd_render_table(rows, :fields => [:Table, :Type, :Count, :Schema], :render_format => op.render_format)
+    $stdout.puts cmd_render_table(rows, :fields => [:Table, :Type, :Count, :Schema], :render_format => op.render_format)
   end
 
   def db_list(op)
@@ -37,7 +37,7 @@ module Command
     dbs.each {|db|
       rows << {:Name=>db.name, :Count=>db.count}
     }
-    puts cmd_render_table(rows, :fields => [:Name, :Count], :render_format => op.render_format)
+    $stdout.puts cmd_render_table(rows, :fields => [:Name, :Count], :render_format => op.render_format)
 
     if dbs.empty?
       $stderr.puts "There are no databases."

--- a/lib/td/command/export.rb
+++ b/lib/td/command/export.rb
@@ -78,7 +78,7 @@ module Command
 
     if wait && !job.finished?
       wait_job(job)
-      puts "Status     : #{job.status}"
+      $stdout.puts "Status     : #{job.status}"
     end
   end
 

--- a/lib/td/command/help.rb
+++ b/lib/td/command/help.rb
@@ -13,7 +13,7 @@ module Command
 
     elsif c.name != cmd && c.group == cmd
       # group command
-      puts List.cmd_usage(cmd)
+      $stdout.puts List.cmd_usage(cmd)
       exit 1
 
     else
@@ -26,8 +26,8 @@ module Command
     cmd = op.cmd_parse
 
     TreasureData::Command::List.show_help(op.summary_indent)
-    puts ""
-    puts "Type '#{$prog} help COMMAND' for more information on a specific command."
+    $stdout.puts ""
+    $stdout.puts "Type '#{$prog} help COMMAND' for more information on a specific command."
   end
 
 end

--- a/lib/td/command/import.rb
+++ b/lib/td/command/import.rb
@@ -27,7 +27,7 @@ module Command
   def import_jar_version(op)
     op.cmd_parse
     version = find_version_file
-    puts "td-import-java #{File.open(version, 'r').read}"
+    $stdout.puts "td-import-java #{File.open(version, 'r').read}"
   end
 
   def import_jar_update(op)
@@ -90,7 +90,7 @@ module Command
       if op.cmd_requires_connectivity
         raise e
       else
-        puts "Warning: JAR update skipped for connectivity issues"
+        $stdout.puts "Warning: JAR update skipped for connectivity issues"
       end
     end
 
@@ -303,7 +303,7 @@ module Command
     installed_path = File.join(File.expand_path('../../..', File.dirname(__FILE__)), 'java')
     config = Command.find_files("logging.properties", [Updater.jarfile_dest_path, installed_path])
     if config.empty?
-      puts "Cannot find 'logging.properties' file in '#{Updater.jarfile_dest_path}' or " +
+      $stdout.puts "Cannot find 'logging.properties' file in '#{Updater.jarfile_dest_path}' or " +
            "'#{installed_path}'." unless ENV['TD_TOOLBELT_DEBUG'].nil?
       []
     else

--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -485,14 +485,14 @@ private
         n_rows += 1
         break if !limit.nil? and n_rows == limit
       }
-      print " " * 100, "\r" # make sure the previous WARNING is cleared over
+      $stdout.print " " * 100, "\r" # make sure the previous WARNING is cleared over
 
       render_opts[:max_width] = 10000
       if job.hive_result_schema
         render_opts[:change_fields] = job.hive_result_schema.map { |name,type| name }
       end
 
-      print "\r" + " " * 50
+      $stdout.print "\r" + " " * 50
       puts "\r" + cmd_render_table(rows, render_opts)
     else
       # display result in any of: json, csv, tsv.

--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -90,7 +90,7 @@ module Command
       }
     }
 
-    puts cmd_render_table(rows,
+    $stdout.puts cmd_render_table(rows,
       :fields => [:JobID, :Status, :Start, :Elapsed, :CPUTime, :ResultSize, :Priority, :Result, :Type, :Database, :Query],
       :max_width => 1000,
       :render_format => op.render_format
@@ -176,7 +176,7 @@ module Command
     job_id = op.cmd_parse
     client = get_client
 
-    puts client.job_status(job_id)
+    $stdout.puts client.job_status(job_id)
   end
 
   def job_kill(op)
@@ -203,27 +203,27 @@ private
     client = get_client
     job = client.job(job_id)
 
-    puts "JobID       : #{job.job_id}"
+    $stdout.puts "JobID       : #{job.job_id}"
     #puts "URL         : #{job.url}"
-    puts "Status      : #{job.status}"
-    puts "Type        : #{job.type}"
-    puts "Database    : #{job.db_name}"
+    $stdout.puts "Status      : #{job.status}"
+    $stdout.puts "Type        : #{job.type}"
+    $stdout.puts "Database    : #{job.db_name}"
     # exclude some fields from bulk_import_perform type jobs
     if [:hive, :pig, :impala, :presto].include?(job.type)
-      puts "Priority    : #{job_priority_name_of(job.priority)}"
-      puts "Retry limit : #{job.retry_limit}"
-      puts "Output      : #{job.result_url}"
-      puts "Query       : #{job.query}"
+      $stdout.puts "Priority    : #{job_priority_name_of(job.priority)}"
+      $stdout.puts "Retry limit : #{job.retry_limit}"
+      $stdout.puts "Output      : #{job.result_url}"
+      $stdout.puts "Query       : #{job.query}"
     elsif job.type == :bulk_import_perform
-      puts "Destination : #{job.query}"
+      $stdout.puts "Destination : #{job.query}"
     end
     # if the job is done and is of type hive, show the Map-Reduce cumulated CPU time
     if job.finished?
       if [:hive].include?(job.type)
-        puts "CPU time    : #{Command.humanize_time(job.cpu_time, true)}"
+        $stdout.puts "CPU time    : #{Command.humanize_time(job.cpu_time, true)}"
       end
       if [:hive, :pig, :impala, :presto].include?(job.type)
-        puts "Result size : #{Command.humanize_bytesize(job.result_size, 2)}"
+        $stdout.puts "Result size : #{Command.humanize_bytesize(job.result_size, 2)}"
       end
     end
 
@@ -239,23 +239,23 @@ private
 
       if verbose
         if !job.debug['cmdout'].nil?
-          puts ""
-          puts "Output:"
+          $stdout.puts ""
+          $stdout.puts "Output:"
           job.debug['cmdout'].to_s.split("\n").each {|line|
-            puts "  " + line
+            $stdout.puts "  " + line
           }
         end
         if !job.debug['stderr'].nil?
-          puts ""
-          puts "Details:"
+          $stdout.puts ""
+          $stdout.puts "Details:"
           job.debug['stderr'].to_s.split("\n").each {|line|
-            puts "  " + line
+            $stdout.puts "  " + line
           }
         end
       end
     end
 
-    puts "\rUse '-v' option to show detailed messages." + " " * 20 unless verbose
+    $stdout.puts "\rUse '-v' option to show detailed messages." + " " * 20 unless verbose
   end
 
   def wait_job(job, first_call = false)
@@ -281,7 +281,7 @@ private
       cmdout = job.debug['cmdout'].to_s.split("\n")[cmdout_lines..-1] || []
       stderr = job.debug['stderr'].to_s.split("\n")[stderr_lines..-1] || []
       (cmdout + stderr).each {|line|
-        puts "  "+line
+        $stdout.puts "  "+line
       }
       cmdout_lines += cmdout.size
       stderr_lines += stderr.size
@@ -294,7 +294,7 @@ private
     max_cumul_retry_delay = 200
     cumul_retry_delay = 0
 
-    puts "Result      :"
+    $stdout.puts "Result      :"
     begin
       show_result(job, output, limit, format, render_opts)
     rescue TreasureData::NotFoundError => e
@@ -320,7 +320,7 @@ private
   def show_result(job, output, limit, format, render_opts={})
     if output
       write_result(job, output, limit, format, render_opts)
-      puts "\rwritten to #{output} in #{format} format" + " " * 50
+      $stdout.puts "\rwritten to #{output} in #{format} format" + " " * 50
     else
       # every format that is allowed on stdout
       render_result(job, limit, format, render_opts)
@@ -352,7 +352,7 @@ private
         f.write "]"
         indicator.finish unless output.nil?
       }
-      puts if output.nil?
+      $stdout.puts if output.nil?
 
     when 'csv'
       require 'yajl'
@@ -493,7 +493,7 @@ private
       end
 
       $stdout.print "\r" + " " * 50
-      puts "\r" + cmd_render_table(rows, render_opts)
+      $stdout.puts "\r" + cmd_render_table(rows, render_opts)
     else
       # display result in any of: json, csv, tsv.
       # msgpack and mspgpack.gz are not supported for stdout output

--- a/lib/td/command/list.rb
+++ b/lib/td/command/list.rb
@@ -46,8 +46,8 @@ module List
     end
 
     def cmd_usage(msg=nil)
-      puts self.to_s
-      puts "Error: #{msg}" if msg
+      $stdout.puts self.to_s
+      $stdout.puts "Error: #{msg}" if msg
       exit 1
     end
   end
@@ -181,9 +181,9 @@ module List
       next if HELP_EXCLUDE.any? {|pattern| pattern =~ c.name }
       if before_group != c.group
         before_group = c.group
-        puts ""
+        $stdout.puts ""
       end
-      puts "#{indent}#{c.usage}"
+      $stdout.puts "#{indent}#{c.usage}"
     }
   end
 

--- a/lib/td/command/password.rb
+++ b/lib/td/command/password.rb
@@ -62,7 +62,7 @@ module Command
         break
       end
 
-      puts "Doesn't match."
+      $stdout.puts "Doesn't match."
     end
 
     client = get_client(:ssl => true)

--- a/lib/td/command/password.rb
+++ b/lib/td/command/password.rb
@@ -10,7 +10,7 @@ module Command
 
     begin
       system "stty -echo"  # TODO termios
-      print "Old password (typing will be hidden): "
+      $stdout.print "Old password (typing will be hidden): "
       old_password = STDIN.gets || ""
       old_password = old_password[0..-2]  # strip \n
     rescue Interrupt
@@ -18,7 +18,7 @@ module Command
       exit 1
     ensure
       system "stty echo"   # TODO termios
-      print "\n"
+      $stdout.print "\n"
     end
 
     if old_password.empty?
@@ -29,7 +29,7 @@ module Command
     3.times do
       begin
         system "stty -echo"  # TODO termios
-        print "New password (typing will be hidden): "
+        $stdout.print "New password (typing will be hidden): "
         password = STDIN.gets || ""
         password = password[0..-2]  # strip \n
       rescue Interrupt
@@ -37,7 +37,7 @@ module Command
         exit 1
       ensure
         system "stty echo"   # TODO termios
-        print "\n"
+        $stdout.print "\n"
       end
 
       if password.empty?
@@ -47,7 +47,7 @@ module Command
 
       begin
         system "stty -echo"  # TODO termios
-        print "Retype new password: "
+        $stdout.print "Retype new password: "
         password2 = STDIN.gets || ""
         password2 = password2[0..-2]  # strip \n
       rescue Interrupt
@@ -55,7 +55,7 @@ module Command
         exit 1
       ensure
         system "stty echo"   # TODO termios
-        print "\n"
+        $stdout.print "\n"
       end
 
       if password == password2

--- a/lib/td/command/query.rb
+++ b/lib/td/command/query.rb
@@ -66,9 +66,9 @@ module Command
       type = s.to_sym
     }
     op.on('--sampling DENOMINATOR', 'OBSOLETE - enable random sampling to reduce records 1/DENOMINATOR', Integer) {|i|
-      puts "WARNING: the random sampling feature enabled through the '--sampling' option was removed and does no longer"
-      puts "         have any effect. It is left for backwards compatibility with older scripts using 'td'."
-      puts
+      $stdout.puts "WARNING: the random sampling feature enabled through the '--sampling' option was removed and does no longer"
+      $stdout.puts "         have any effect. It is left for backwards compatibility with older scripts using 'td'."
+      $stdout.puts
     }
     op.on('-l', '--limit ROWS', 'limit the number of result rows shown when not outputting to file') {|s|
       unless s.to_i > 0
@@ -132,15 +132,15 @@ module Command
     opts['type'] = type if type
     job = client.query(db_name, sql, result_url, priority, retry_limit, opts)
 
-    puts "Job #{job.job_id} is queued."
-    puts "Use '#{$prog} " + Config.cl_options_string + "job:show #{job.job_id}' to show the status."
+    $stdout.puts "Job #{job.job_id} is queued."
+    $stdout.puts "Use '#{$prog} " + Config.cl_options_string + "job:show #{job.job_id}' to show the status."
     #puts "See #{job.url} to see the progress."
 
     if wait
       wait_job(job, true)
-      puts "Status     : #{job.status}"
+      $stdout.puts "Status     : #{job.status}"
       if job.success? && !exclude
-        puts "Result     :"
+        $stdout.puts "Result     :"
         begin
           show_result(job, output, limit, format, render_opts)
         rescue TreasureData::NotFoundError => e

--- a/lib/td/command/result.rb
+++ b/lib/td/command/result.rb
@@ -15,8 +15,8 @@ module Command
       exit 1
     end
 
-    puts "Name : #{r.name}"
-    puts "URL  : #{r.url}"
+    $stdout.puts "Name : #{r.name}"
+    $stdout.puts "URL  : #{r.url}"
   end
 
   def result_list(op)
@@ -36,7 +36,7 @@ module Command
       map[:Name]
     }
 
-    puts cmd_render_table(rows, :fields => [:Name, :URL], :render_format => op.render_format)
+    $stdout.puts cmd_render_table(rows, :fields => [:Name, :URL], :render_format => op.render_format)
 
     if rs.empty?
       $stderr.puts "There are no result URLs."

--- a/lib/td/command/result.rb
+++ b/lib/td/command/result.rb
@@ -93,7 +93,7 @@ module Command
     if ask_password
       begin
         system "stty -echo"  # TODO termios
-        print "Password (typing will be hidden): "
+        $stdout.print "Password (typing will be hidden): "
         password = STDIN.gets || ""
         password = password[0..-2]  # strip \n
       rescue Interrupt
@@ -101,7 +101,7 @@ module Command
         exit 1
       ensure
         system "stty echo"   # TODO termios
-        print "\n"
+        $stdout.print "\n"
       end
     end
 

--- a/lib/td/command/runner.rb
+++ b/lib/td/command/runner.rb
@@ -32,9 +32,9 @@ EOF
     (class << self;self;end).module_eval do
       define_method(:usage) do |errmsg|
         require 'td/command/list'
-        puts op.to_s
-        puts ""
-        puts <<EOF
+        $stdout.puts op.to_s
+        $stdout.puts ""
+        $stdout.puts <<EOF
 Basic commands:
 
   db             # create/delete/list databases
@@ -59,7 +59,7 @@ Additional commands:
 Type 'td help COMMAND' for more information on a specific command.
 EOF
         if errmsg
-          puts "Error: #{errmsg}"
+          $stdout.puts "Error: #{errmsg}"
           return 1
         else
           return 0
@@ -116,7 +116,7 @@ EOF
     }
 
     op.on('--version', "show version") {
-      puts op.version
+      $stdout.puts op.version
       return 0
     }
 
@@ -191,13 +191,13 @@ EOF
         $!.backtrace.each {|bt|
           $stderr.puts "  #{bt}"
         }
-        puts ""
+        $stdout.puts ""
       end
       $stdout.print "Error: "
       if [ForbiddenError, NotFoundError, AuthError].include?(e.class)
         $stdout.print "#{e.class} - "
       end
-      puts $!.to_s
+      $stdout.puts $!.to_s
 
       require 'socket'
       if e.is_a?(::SocketError)

--- a/lib/td/command/runner.rb
+++ b/lib/td/command/runner.rb
@@ -193,9 +193,9 @@ EOF
         }
         puts ""
       end
-      print "Error: "
+      $stdout.print "Error: "
       if [ForbiddenError, NotFoundError, AuthError].include?(e.class)
-        print "#{e.class} - "
+        $stdout.print "#{e.class} - "
       end
       puts $!.to_s
 

--- a/lib/td/command/sched.rb
+++ b/lib/td/command/sched.rb
@@ -20,7 +20,7 @@ module Command
       map[:Name]
     }
 
-    puts cmd_render_table(rows, :fields => [:Name, :Cron, :Timezone, :"Next schedule", :Delay, :Priority, :Result, :Database, :Query], :max_width=>500, :render_format => op.render_format)
+    $stdout.puts cmd_render_table(rows, :fields => [:Name, :Cron, :Timezone, :"Next schedule", :Delay, :Priority, :Result, :Database, :Query], :max_width=>500, :render_format => op.render_format)
   end
 
   def sched_create(op)
@@ -218,9 +218,9 @@ module Command
     end
 
     if newname && curname != newname
-      puts "Schedule '#{curname}' is updated and its name changed to '#{newname}'."
+      $stdout.puts "Schedule '#{curname}' is updated and its name changed to '#{newname}'."
     else
-      puts "Schedule '#{curname}' is updated."
+      $stdout.puts "Schedule '#{curname}' is updated."
     end
   end
 
@@ -259,16 +259,16 @@ module Command
 
     scheds = client.schedules
     if s = scheds.find {|s| s.name == name }
-      puts "Name        : #{s.name}"
-      puts "Cron        : #{s.cron}"
-      puts "Timezone    : #{s.timezone}"
-      puts "Delay       : #{s.delay} sec"
-      puts "Next        : #{s.next_time}"
-      puts "Result      : #{s.result_url}"
-      puts "Priority    : #{job_priority_name_of(s.priority)}"
-      puts "Retry limit : #{s.retry_limit}"
-      puts "Database    : #{s.database}"
-      puts "Query       : #{s.query}"
+      $stdout.puts "Name        : #{s.name}"
+      $stdout.puts "Cron        : #{s.cron}"
+      $stdout.puts "Timezone    : #{s.timezone}"
+      $stdout.puts "Delay       : #{s.delay} sec"
+      $stdout.puts "Next        : #{s.next_time}"
+      $stdout.puts "Result      : #{s.result_url}"
+      $stdout.puts "Priority    : #{job_priority_name_of(s.priority)}"
+      $stdout.puts "Retry limit : #{s.retry_limit}"
+      $stdout.puts "Database    : #{s.database}"
+      $stdout.puts "Query       : #{s.query}"
     end
 
     rows = []
@@ -277,7 +277,7 @@ module Command
       rows << {:Time => scheduled_at, :JobID => j.job_id, :Status => j.status, :Priority => job_priority_name_of(j.priority), :Result=>j.result_url}
     }
 
-    puts cmd_render_table(rows, :fields => [:JobID, :Time, :Status, :Priority, :Result], :render_format => op.render_format)
+    $stdout.puts cmd_render_table(rows, :fields => [:JobID, :Time, :Status, :Priority, :Result], :render_format => op.render_format)
   end
 
   def sched_run(op)
@@ -320,7 +320,7 @@ module Command
     }
 
     $stderr.puts "Scheduled #{num} jobs from #{t}."
-    puts cmd_render_table(rows, :fields => [:JobID, :Time], :max_width=>500, :render_format => op.render_format)
+    $stdout.puts cmd_render_table(rows, :fields => [:JobID, :Time], :max_width=>500, :render_format => op.render_format)
   end
 
 end # module Command

--- a/lib/td/command/schema.rb
+++ b/lib/td/command/schema.rb
@@ -8,11 +8,11 @@ module Command
     client = get_client
     table = get_table(client, db_name, table_name)
 
-    puts "#{db_name}.#{table_name} ("
+    $stdout.puts "#{db_name}.#{table_name} ("
     table.schema.fields.each {|f|
-      puts "  #{f.name}:#{f.type}"
+      $stdout.puts "  #{f.name}:#{f.type}"
     }
-    puts ")"
+    $stdout.puts ")"
   end
 
   def schema_set(op)

--- a/lib/td/command/server.rb
+++ b/lib/td/command/server.rb
@@ -6,7 +6,7 @@ module Command
   def server_status(op)
     op.cmd_parse
 
-    puts Client.server_status
+    $stdout.puts Client.server_status
   end
 
   def server_endpoint(op)

--- a/lib/td/command/status.rb
+++ b/lib/td/command/status.rb
@@ -75,7 +75,7 @@ module Command
     height = 0
     lines.each {|line|
       $stdout.print "\e[#{movex}C" if movex > 0
-      puts line
+      $stdout.puts line
       width = line.length
       max_width = width if max_width < width
       height += 1

--- a/lib/td/command/status.rb
+++ b/lib/td/command/status.rb
@@ -57,9 +57,9 @@ module Command
     x4, y4 = status_render(x3+2, y3, "[Results]", results, :fields => [:Name, :URL])
 
     (y3-y4-1).times do
-      print "\eD"
+      $stdout.print "\eD"
     end
-    print "\eE"
+    $stdout.print "\eE"
   end
 
   private
@@ -69,12 +69,12 @@ module Command
     lines.unshift(msg)
     #lines.unshift("")
 
-    print "\e[#{movey}A" if movey > 0
+    $stdout.print "\e[#{movey}A" if movey > 0
 
     max_width = 0
     height = 0
     lines.each {|line|
-      print "\e[#{movex}C" if movex > 0
+      $stdout.print "\e[#{movex}C" if movex > 0
       puts line
       width = line.length
       max_width = width if max_width < width

--- a/lib/td/command/table.rb
+++ b/lib/td/command/table.rb
@@ -191,7 +191,7 @@ module Command
     else
       fields = [:Database, :Table, :Type, :Count, :Size, 'Last import', 'Last log timestamp', :Schema]
     end
-    puts cmd_render_table(rows, :fields => fields, :max_width => 500, :render_format => op.render_format)
+    $stdout.puts cmd_render_table(rows, :fields => fields, :max_width => 500, :render_format => op.render_format)
 
     if rows.empty?
       if db_name
@@ -231,16 +231,16 @@ module Command
 
     table = get_table(client, db_name, table_name)
 
-    puts "Name        : #{table.db_name}.#{table.name}"
-    puts "Type        : #{table.type}"
-    puts "Count       : #{table.count}"
-    # p table.methods.each {|m| puts m}
-    puts "Primary key : #{table.primary_key}:#{table.primary_key_type}" if table.type == :item
-    puts "Schema      : ("
+    $stdout.puts "Name        : #{table.db_name}.#{table.name}"
+    $stdout.puts "Type        : #{table.type}"
+    $stdout.puts "Count       : #{table.count}"
+    # p table.methods.each {|m| $stdout.puts m}
+    $stdout.puts "Primary key : #{table.primary_key}:#{table.primary_key_type}" if table.type == :item
+    $stdout.puts "Schema      : ("
     table.schema.fields.each {|f|
-      puts "    #{f.name}:#{f.type}"
+      $stdout.puts "    #{f.name}:#{f.type}"
     }
-    puts ")"
+    $stdout.puts ")"
   end
 
   def table_tail(op)
@@ -288,11 +288,11 @@ module Command
         :space => ' '
       }
       rows.each {|row|
-        puts row.to_json(opts)
+        $stdout.puts row.to_json(opts)
       }
     else
       rows.each {|row|
-        puts row.to_json
+        $stdout.puts row.to_json
       }
     end
   end
@@ -357,7 +357,7 @@ module Command
 
     if wait && !job.finished?
       wait_job(job)
-      puts "Status     : #{job.status}"
+      $stdout.puts "Status     : #{job.status}"
     end
   end
 
@@ -374,9 +374,9 @@ module Command
     client.update_expire(db_name, table_name, expire_days)
 
     if expire_days == 0
-      puts "Data expiration disabled for this table."
+      $stdout.puts "Data expiration disabled for this table."
     else
-      puts "Table set to expire data older than #{expire_days} days."
+      $stdout.puts "Table set to expire data older than #{expire_days} days."
     end
   end
 
@@ -488,12 +488,12 @@ module Command
     begin
       db = client.database(db_name)
     rescue ForbiddenError => e
-      puts "Warning: database and table validation skipped - #{e.message}"
+      $stdout.puts "Warning: database and table validation skipped - #{e.message}"
     else
       begin
         table = db.table(table_name)
       rescue ForbiddenError => e
-        puts "Warning: table validation skipped - #{e.message}"
+        $stdout.puts "Warning: table validation skipped - #{e.message}"
       end
     end
 
@@ -522,12 +522,12 @@ module Command
       import_log_file(file, path, client, db_name, table_name, parser)
     }
 
-    puts "done."
+    $stdout.puts "done."
   end
 
   private
   def import_log_file(file, path, client, db_name, table_name, parser)
-    puts "importing #{path}..."
+    $stdout.puts "importing #{path}..."
 
     out = Tempfile.new('td-import')
     out.binmode if out.respond_to?(:binmode)
@@ -549,17 +549,17 @@ module Command
       n += 1
       x += 1
       if n % 10000 == 0   # by records imported
-        puts "  imported #{n} entries from #{path}..."
+        $stdout.puts "  imported #{n} entries from #{path}..."
 
       # TODO size
       elsif out.pos > 1024 * 1024   # by 1 MB chunks
-        puts "  imported #{n} entries from #{path}..."
+        $stdout.puts "  imported #{n} entries from #{path}..."
         begin
           writer.finish
           size = out.pos
           out.pos = 0
 
-          puts "  uploading #{size} bytes..."
+          $stdout.puts "  uploading #{size} bytes..."
           client.import(db_name, table_name, "msgpack.gz", out, size)
 
           out.truncate(0)
@@ -579,7 +579,7 @@ module Command
       size = out.pos
       out.pos = 0
 
-      puts "  uploading #{size} bytes..."
+      $stdout.puts "  uploading #{size} bytes..."
       # TODO upload on background thread
       client.import(db_name, table_name, "msgpack.gz", out, size)
     end
@@ -589,7 +589,7 @@ module Command
       raise ImportError, "no valid record to import from #{path}"
     end
 
-    puts "  imported #{n} entries from #{path}."
+    $stdout.puts "  imported #{n} entries from #{path}."
     $stderr.puts normalized_message if has_bignum
   ensure
     out.close rescue nil

--- a/lib/td/command/update.rb
+++ b/lib/td/command/update.rb
@@ -12,11 +12,11 @@ module Command
     end
 
     start_time = Time.now
-    puts "Updating 'td' from #{TOOLBELT_VERSION}..."
+    $stdout.puts "Updating 'td' from #{TOOLBELT_VERSION}..."
     if new_version = Updater.update
-      puts "Successfully updated to #{new_version} in #{Command.humanize_time((Time.now - start_time).to_i)}."
+      $stdout.puts "Successfully updated to #{new_version} in #{Command.humanize_time((Time.now - start_time).to_i)}."
     else
-      puts "Nothing to update."
+      $stdout.puts "Nothing to update."
     end
   end
 

--- a/lib/td/command/user.rb
+++ b/lib/td/command/user.rb
@@ -33,7 +33,7 @@ module Command
       rows << {:Name => user.name, :Email => user.email}
     }
 
-    puts cmd_render_table(rows, :fields => [:Name, :Email], :render_format => op.render_format)
+    $stdout.puts cmd_render_table(rows, :fields => [:Name, :Email], :render_format => op.render_format)
 
     if rows.empty?
       $stderr.puts "There are no users."
@@ -73,7 +73,7 @@ module Command
       1.times { r << symbol.sort_by{rand}.first }
       password = r.sort_by{rand}.join
 
-      puts "Password: #{password}"
+      $stdout.puts "Password: #{password}"
 
     else
       3.times do
@@ -112,7 +112,7 @@ module Command
           break
         end
 
-        puts "Doesn't match."
+        $stdout.puts "Doesn't match."
       end
     end
 
@@ -185,7 +185,7 @@ module Command
       rows << {:Key => key}
     }
 
-    puts cmd_render_table(rows, :fields => [:Key], :render_format => op.render_format)
+    $stdout.puts cmd_render_table(rows, :fields => [:Key], :render_format => op.render_format)
   end
 
   def user_password_change(op)
@@ -229,7 +229,7 @@ module Command
         break
       end
 
-      puts "Doesn't match."
+      $stdout.puts "Doesn't match."
     end
 
     client = get_client(:ssl => true)

--- a/lib/td/command/user.rb
+++ b/lib/td/command/user.rb
@@ -79,7 +79,7 @@ module Command
       3.times do
         begin
           system "stty -echo"  # TODO termios
-          print "Password (typing will be hidden): "
+          $stdout.print "Password (typing will be hidden): "
           password = STDIN.gets || ""
           password = password[0..-2]  # strip \n
         rescue Interrupt
@@ -87,7 +87,7 @@ module Command
           exit 1
         ensure
           system "stty echo"   # TODO termios
-          print "\n"
+          $stdout.print "\n"
         end
 
         if password.empty?
@@ -97,7 +97,7 @@ module Command
 
         begin
           system "stty -echo"  # TODO termios
-          print "Retype password: "
+          $stdout.print "Retype password: "
           password2 = STDIN.gets || ""
           password2 = password2[0..-2]  # strip \n
         rescue Interrupt
@@ -105,7 +105,7 @@ module Command
           exit 1
         ensure
           system "stty echo"   # TODO termios
-          print "\n"
+          $stdout.print "\n"
         end
 
         if password == password2
@@ -196,7 +196,7 @@ module Command
     3.times do
       begin
         system "stty -echo"  # TODO termios
-        print "New password (typing will be hidden): "
+        $stdout.print "New password (typing will be hidden): "
         password = STDIN.gets || ""
         password = password[0..-2]  # strip \n
       rescue Interrupt
@@ -204,7 +204,7 @@ module Command
         exit 1
       ensure
         system "stty echo"   # TODO termios
-        print "\n"
+        $stdout.print "\n"
       end
 
       if password.empty?
@@ -214,7 +214,7 @@ module Command
 
       begin
         system "stty -echo"  # TODO termios
-        print "Retype new password: "
+        $stdout.print "Retype new password: "
         password2 = STDIN.gets || ""
         password2 = password2[0..-2]  # strip \n
       rescue Interrupt
@@ -222,7 +222,7 @@ module Command
         exit 1
       ensure
         system "stty echo"   # TODO termios
-        print "\n"
+        $stdout.print "\n"
       end
 
       if password == password2

--- a/lib/td/updater.rb
+++ b/lib/td/updater.rb
@@ -173,7 +173,7 @@ module ModuleDefinition
           end
           indicator.finish
 
-          print "Unpacking updated toolbelt package..."
+          $stdout.print "Unpacking updated toolbelt package..."
           Zip::ZipFile.open("#{download_dir}/td-update.zip") do |zip|
             zip.each do |entry|
               target = File.join(download_dir, entry.to_s)
@@ -181,7 +181,7 @@ module ModuleDefinition
               zip.extract(entry, target) { true }
             end
           end
-          print "done\n"
+          $stdout.print "done\n"
 
           FileUtils.rm "#{download_dir}/td-update.zip"
 
@@ -270,7 +270,7 @@ module ModuleDefinition
 
     http.request_get(uri.path) {|response|
       if response.class == Net::HTTPOK
-        # print a . every tick_period seconds
+        # $stdout.print a . every tick_period seconds
         response.read_body do |chunk|
           binfile.write chunk
           progress.call unless progress.nil?

--- a/lib/td/updater.rb
+++ b/lib/td/updater.rb
@@ -166,7 +166,7 @@ module ModuleDefinition
           # downloading the update compressed file
           File.open("#{download_dir}/td-update.zip", "wb") do |file|
             endpoint = update_package_endpoint
-            puts "\npackage '#{endpoint}'... " unless ENV['TD_TOOLBELT_DEBUG'].nil?
+            $stdout.puts "\npackage '#{endpoint}'... " unless ENV['TD_TOOLBELT_DEBUG'].nil?
             stream_fetch(endpoint, file) {
               indicator.update
             }
@@ -279,7 +279,7 @@ module ModuleDefinition
       elsif response.class == Net::HTTPFound || \
             response.class == Net::HTTPRedirection
         unless ENV['TD_TOOLBELT_DEBUG'].nil?
-          puts "redirect '#{url}' to '#{response['Location']}'... "
+          $stdout.puts "redirect '#{url}' to '#{response['Location']}'... "
         end
         return stream_fetch(response['Location'], binfile, &progress)
       else
@@ -353,15 +353,15 @@ end # module ModuleDefinition
         indicator.finish()
 
         if status
-          puts "Installed td-import.jar v#{version} in '#{Updater.jarfile_dest_path}'.\n"
+          $stdout.puts "Installed td-import.jar v#{version} in '#{Updater.jarfile_dest_path}'.\n"
           File.rename 'td-import.jar.new', 'td-import.jar'
         else
-          puts "Update of td-import.jar failed." unless ENV['TD_TOOLBELT_DEBUG'].nil?
+          $stdout.puts "Update of td-import.jar failed." unless ENV['TD_TOOLBELT_DEBUG'].nil?
           File.delete 'td-import.jar.new' if File.exists? 'td-import.jar.new'
         end
       end
     else
-      puts 'Installed td-import.jar is already at the latest version.' unless hourly
+      $stdout.puts 'Installed td-import.jar is already at the latest version.' unless hourly
     end
   end
 
@@ -370,7 +370,7 @@ end # module ModuleDefinition
       if !ENV['TD_TOOLBELT_JAR_UPDATE'].nil?
         # also validates the TD_TOOLBELT_JAR_UPDATE environment variable value
         if ENV['TD_TOOLBELT_JAR_UPDATE'] == "0"
-          puts "Warning: Bulk Import JAR auto-update disabled by TD_TOOLBELT_JAR_UPDATE=0"
+          $stdout.puts "Warning: Bulk Import JAR auto-update disabled by TD_TOOLBELT_JAR_UPDATE=0"
           return
         elsif ENV['TD_TOOLBELT_JAR_UPDATE'] != "1"
           raise UpdateError,


### PR DESCRIPTION
Prepare for next job, e.g. adding silence option, output refactoring, etc.
Always use `$stdout.puts` is grep/sed friendly.