### PR TITLE
gsub without bang

### DIFF
--- a/lib/td/helpers.rb
+++ b/lib/td/helpers.rb
@@ -3,12 +3,7 @@ module TreasureData
     module_function
 
     def format_with_delimiter(number, delimiter = ',')
-      num = number.to_s
-      if formatted = num.gsub!(/(\d)(?=(?:\d{3})+(?!\d))/, "\\1#{delimiter}")
-        formatted
-      else
-        num
-      end
+      number.to_s.gsub(/(\d)(?=(?:\d{3})+(?!\d))/, "\\1#{delimiter}")
     end
 
     def home_directory

--- a/spec/td/command/table_spec.rb
+++ b/spec/td/command/table_spec.rb
@@ -130,11 +130,8 @@ module TreasureData::Command
         before do
           create_tables = lambda {|db_name|
             (1..6).map {|i|
-              # NOTE: TreasureData::Helpers.format_with_delimiter uses `gsub!` to their argument
-              #       the argument (in our case, `number_raw`) will be rewritten by them
-              #       To avoid that behavior, pass `number_raw.dup` instead of `number_raw`
               schema = TreasureData::Schema.new.from_json(JSON.parse('[]'))
-              TreasureData::Table.new(client, db_name, db_name + "_table_#{i}", 'log', schema, number_raw.dup, Time.now.to_i, Time.now.to_i, 0, nil, nil, nil, nil, nil)
+              TreasureData::Table.new(client, db_name, db_name + "_table_#{i}", 'log', schema, number_raw, Time.now.to_i, Time.now.to_i, 0, nil, nil, nil, nil, nil)
             }
           }
           db_tables = create_tables.call(db.name)


### PR DESCRIPTION
Fix #54 

`format_with_delimiter` method is already covered by this spec.
https://github.com/treasure-data/td/blob/master/spec/td/helpers_spec.rb