### PR TITLE
Fix connector:show, update, delete, etc. fix #75

### DIFF
--- a/lib/td/command/connector.rb
+++ b/lib/td/command/connector.rb
@@ -283,14 +283,14 @@ private
   end
 
   def dump_connector_session(session)
-    $stdout.puts "Name     : #{session.name}"
-    $stdout.puts "Cron     : #{session.cron}"
-    $stdout.puts "Timezone : #{session.timezone}"
-    $stdout.puts "Delay    : #{session.delay}"
-    $stdout.puts "Database : #{session.database}"
-    $stdout.puts "Table    : #{session.table}"
+    $stdout.puts "Name     : #{session["name"]}"
+    $stdout.puts "Cron     : #{session["cron"]}"
+    $stdout.puts "Timezone : #{session["timezone"]}"
+    $stdout.puts "Delay    : #{session["delay"]}"
+    $stdout.puts "Database : #{session["database"]}"
+    $stdout.puts "Table    : #{session["table"]}"
     $stdout.puts "Config"
-    $stdout.puts YAML.dump(session.config)
+    $stdout.puts YAML.dump(session["config"])
   end
 
   def wait_connector_job(client, job_id, exclude)


### PR DESCRIPTION
I've grepped then found that `client.bulk_load_*` API changes effect `td connector:*` commands only.

```console
$ git grep -n bulk_load_
lib/td/command/connector.rb:56:    job = client.bulk_load_guess(job)
lib/td/command/connector.rb:81:    preview = client.bulk_load_preview(job)
lib/td/command/connector.rb:121:    job_id = client.bulk_load_issue(database, table, job)
lib/td/command/connector.rb:139:    rows = client.bulk_load_list().sort_by { |e|
lib/td/command/connector.rb:175:    session = client.bulk_load_create(name, database, table, job, opts)
lib/td/command/connector.rb:183:    session = client.bulk_load_show(name)
lib/td/command/connector.rb:193:    session = client.bulk_load_update(name, job)
lib/td/command/connector.rb:201:    session = client.bulk_load_delete(name)
lib/td/command/connector.rb:213:    rows = client.bulk_load_history(name).map { |e|
lib/td/command/connector.rb:237:    job_id = client.bulk_load_run(name)
spec/td/command/connector_spec.rb:45:        TreasureData::Client.any_instance.stub(:bulk_load_preview).and_return(preview_result)
```