### PR TITLE
DownloadProgressIndicator with 'ruby-progressbar'

### DIFF
--- a/lib/td/command/common.rb
+++ b/lib/td/command/common.rb
@@ -388,11 +388,11 @@ EOS
       require 'ruby-progressbar'
 
       @total_size = total_size
-      @total_byte_size = Command.humanize_bytesize(@total_size) if @total_size
+      @total_byte_size = Command.humanize_bytesize(@total_size) unless unknown_progress_mode?
 
       @progress_bar = ProgressBar.create(
         title: msg,
-        total: total_size == 0 ? nil : total_size,
+        total: unknown_progress_mode? ? nil : @total_size,
         format: formated_title(0),
         output: $stdout,
       )
@@ -410,7 +410,7 @@ EOS
     end
 
     def update(curr_size)
-      if @total_size.nil? || @total_size == 0
+      if unknown_progress_mode?
         update_progress_bar(curr_size)
         true
       else
@@ -429,7 +429,7 @@ EOS
     end
 
     def finish
-      if @total_size.nil? || @total_size == 0
+      if unknown_progress_mode?
         @progress_bar.format = "%t : #{Command.humanize_bytesize(@progress_bar.progress)} Done"
         @progress_bar.progress = 0
       else
@@ -439,13 +439,17 @@ EOS
 
     private
 
+    def unknown_progress_mode?
+      @total_size.nil? || @total_size == 0
+    end
+
     def update_progress_bar(curr_size)
       @progress_bar.format = formated_title(curr_size)
       @progress_bar.progress = curr_size
     end
 
     def formated_title(curr_size)
-      if @total_size.nil? || @total_size == 0
+      if unknown_progress_mode?
         "%t : #{Command.humanize_bytesize(curr_size).rjust(10)}"
       else
         rjust_size = @total_byte_size.size + 1

--- a/lib/td/command/common.rb
+++ b/lib/td/command/common.rb
@@ -411,6 +411,7 @@ EOS
         format: formated_title(0),
         output: $stdout,
       )
+      @progress_bar.refresh
 
       # perc_step is how small a percentage increment can be shown
       @perc_step = perc_step

--- a/lib/td/command/common.rb
+++ b/lib/td/command/common.rb
@@ -384,8 +384,8 @@ EOS
   end
 
   class SizeBasedDownloadProgressIndicator < DownloadProgressIndicator
-    def initialize(msg, size, perc_step = 1, min_periodicity = nil)
-      @size = size
+    def initialize(msg, total_size, perc_step = 1, min_periodicity = nil)
+      @total_size = total_size
 
       # perc_step is how small a percentage increment can be shown
       @perc_step = perc_step
@@ -402,12 +402,12 @@ EOS
     end
 
     def update(curr_size)
-      if @size.nil? || @size == 0
+      if @total_size.nil? || @total_size == 0
         msg = "\r#{@base_msg}: #{Command.humanize_bytesize(curr_size)}"
         $stdout.print msg
         true
       else
-        ratio = (curr_size.to_f * 100 / @size).round(1)
+        ratio = (curr_size.to_f * 100 / @total_size).round(1)
         if ratio >= (@last_perc_step + @perc_step) &&
            (!@min_periodicity || (time = Time.now.to_i) - @last_time >= @min_periodicity)
           msg = "\r#{@base_msg}: #{Command.humanize_bytesize(curr_size)} / #{ratio}%"

--- a/lib/td/command/common.rb
+++ b/lib/td/command/common.rb
@@ -446,7 +446,7 @@ EOS
 
     def finish
       if unknown_progress_mode?
-        @progress_bar.format = "%t : #{Command.humanize_bytesize(@progress_bar.progress)} Done"
+        @progress_bar.format = "%t : #{Command.humanize_bytesize(@progress_bar.progress).rjust(10)} Done"
         @progress_bar.progress = 0
       else
         update_progress_bar(@progress_bar.total)

--- a/lib/td/command/common.rb
+++ b/lib/td/command/common.rb
@@ -351,14 +351,7 @@ EOS
     files
   end
 
-  class DownloadProgressIndicator
-    def initialize(msg)
-      @base_msg = msg
-      $stdout.print @base_msg + " " * 10
-    end
-  end
-
-  class TimeBasedDownloadProgressIndicator < DownloadProgressIndicator
+  class TimeBasedDownloadProgressIndicator
     def initialize(msg, start_time, periodicity = 2)
       require 'ruby-progressbar'
 
@@ -405,7 +398,7 @@ EOS
     end
   end
 
-  class SizeBasedDownloadProgressIndicator < DownloadProgressIndicator
+  class SizeBasedDownloadProgressIndicator
     def initialize(msg, total_size, perc_step = 1, min_periodicity = nil)
       require 'ruby-progressbar'
 

--- a/spec/td/common_spec.rb
+++ b/spec/td/common_spec.rb
@@ -144,7 +144,7 @@ module TreasureData::Command
       size_increments = 2
       curr_size = 0
       while (curr_size += size_increments) < size do
-        indicator.update(size_increments)
+        indicator.update(curr_size)
         sleep(0.05)
       end
       indicator.finish

--- a/spec/td/common_spec.rb
+++ b/spec/td/common_spec.rb
@@ -149,6 +149,28 @@ module TreasureData::Command
       end
       indicator.finish
     end
+
+    it "shows in only current byte size if total is nil" do
+      indicator = TreasureData::Command::SizeBasedDownloadProgressIndicator.new("Downloading", nil)
+      size_increments = 2
+      curr_size = 0
+      while (curr_size += size_increments) < 200 do
+        indicator.update(curr_size)
+        sleep(0.05)
+      end
+      indicator.finish
+    end
+
+    it "shows in only current byte size if total is 0" do
+      indicator = TreasureData::Command::SizeBasedDownloadProgressIndicator.new("Downloading", 0)
+      size_increments = 2
+      curr_size = 0
+      while (curr_size += size_increments) < 200 do
+        indicator.update(curr_size)
+        sleep(0.05)
+      end
+      indicator.finish
+    end
   end
 
   describe 'TimeBasedDownloadProgressIndicator' do

--- a/td.gemspec
+++ b/td.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "td-logger", "~> 0.3.21"
   gem.add_dependency "rubyzip", "~> 1.1.7"
   gem.add_dependency "zip-zip", "~> 0.3"
+  gem.add_dependency "ruby-progressbar", "~> 1.7.5"
   gem.add_development_dependency "rake", "~> 0.9"
   gem.add_development_dependency "rspec", "~> 2.11.0"
   gem.add_development_dependency "simplecov", "~> 0.10.0"


### PR DESCRIPTION
ref #45

So, Now it has become to look like the following.

| indicator | status | image |
|------------|-----------|-----------|
| TimeBasedDownloadProgressIndicator | progress | ![](https://cloud.githubusercontent.com/assets/43500/8471585/cb0965e4-20d4-11e5-8efa-532367eb3368.png) |
| TimeBasedDownloadProgressIndicator | finished | ![](https://cloud.githubusercontent.com/assets/43500/8471589/e5561776-20d4-11e5-8ac6-64380486859d.png) |
| SizeBasedDownloadProgressIndicator with total_size | progress |![](https://cloud.githubusercontent.com/assets/43500/8471621/2f4e8e62-20d5-11e5-8930-182c7971f180.png)
| SizeBasedDownloadProgressIndicator with total_size | finished |  ![](https://cloud.githubusercontent.com/assets/43500/8471597/0384ce22-20d5-11e5-9401-0186076f0225.png) |
| SizeBasedDownloadProgressIndicator without total_size | progress | ![](https://cloud.githubusercontent.com/assets/43500/8471632/4f0c4712-20d5-11e5-8842-e3a18c8416be.png)
| SizeBasedDownloadProgressIndicator without total_size | finished | ![](https://cloud.githubusercontent.com/assets/43500/8471634/52c4096c-20d5-11e5-8c9b-83f607da89db.png)

