### PR TITLE
connector:guess shows help message if no arguments are set

### DIFF
--- a/lib/td/command/connector.rb
+++ b/lib/td/command/connector.rb
@@ -36,8 +36,8 @@ module Command
         required('--out', out)
       rescue ParameterConfigurationError
         if id == nil && secret == nil && source == nil
-          puts op.to_s
-          puts ""
+          $stdout.puts op.to_s
+          $stdout.puts ""
           raise ParameterConfigurationError, "path to configuration file is required"
         else
           raise

--- a/lib/td/command/connector.rb
+++ b/lib/td/command/connector.rb
@@ -18,21 +18,31 @@ module Command
     id = secret = source = nil
     out = 'td-bulkload.yml'
 
-    op.on('--type[=TYPE]', "connector type; only 's3' is supported") { |s| type = s }
-    op.on('--access-id ID', "access ID (S3 access key id for type: s3)") { |s| id = s }
-    op.on('--access-secret SECRET', "access secret (S3 secret access key for type: s3)") { |s| secret = s }
-    op.on('--source SOURCE', "resource(s) URI to be imported (e.g. https://s3-us-west-1.amazonaws.com/bucketname/path/prefix/to/import/)") { |s| source = s }
-    op.on('--out FILE_NAME', "configuration file") { |s| out = s }
+    op.on('--type[=TYPE]', "(obsoleted)") { |s| type = s }
+    op.on('--access-id ID', "(obsoleted)") { |s| id = s }
+    op.on('--access-secret SECRET', "(obsoleted)") { |s| secret = s }
+    op.on('--source SOURCE', "(obsoleted)") { |s| source = s }
+    op.on('-o', '--out FILE_NAME', "output file name for connector:preview") { |s| out = s }
 
     config = op.cmd_parse
     if config
       job = prepare_bulkload_job_config(config)
       out ||= config
     else
-      required('--access-id', id)
-      required('--access-secret', secret)
-      required('--source', source)
-      required('--out', out)
+      begin
+        required('--access-id', id)
+        required('--access-secret', secret)
+        required('--source', source)
+        required('--out', out)
+      rescue ParameterConfigurationError
+        if id == nil && secret == nil && source == nil
+          puts op.to_s
+          puts ""
+          raise ParameterConfigurationError, "path to configuration file is required"
+        else
+          raise
+        end
+      end
 
       uri = URI.parse(source)
       endpoint = uri.host

--- a/lib/td/command/list.rb
+++ b/lib/td/command/list.rb
@@ -332,7 +332,17 @@ module List
 
   add_list 'update', %w[], 'Update td and related libraries for TreasureData toolbelt'
 
-  add_list 'connector:guess', %w[config?], 'Run guess to generate connector config file', ['connector:guess td-bulkload.yml', 'connector:guess --access-id s3accessId --access-secret s3AccessKey --source https://s3.amazonaws.com/bucketname/path/prefix --database connector_database --table connector_table']
+  connector_guess_example_config = "
+  in:
+    type: s3
+    bucket: my-s3-bucket
+    endpoint: s3-us-west-1.amazonaws.com
+    path_prefix: path/prefix/to/import/
+    access_key_id: ABCXYZ123ABCXYZ123
+    secret_access_key: AbCxYz123aBcXyZ123
+  out:
+    mode: append"
+  add_list 'connector:guess', %w[config?], 'Run guess to generate connector config file', ["connector:guess config.yml -o td-bulkload.yml\n\nexample config.yml:#{connector_guess_example_config}"]
   add_list 'connector:preview', %w[config], 'Show preview of connector execution', ['connector:preview td-bulkload.yml']
 
   add_list 'connector:issue', %w[config], 'Run one time connector execution', ['connector:issue td-bulkload.yml']


### PR DESCRIPTION
Setting --access-id, --access-secret, and --source doesn't make sense
because now connector supports other data sources such as mysql.
This pull-request changes help message of connector:guess shown when
executed with no arguments to suggest users to use configuration file
rather showing "Error: --access-id option required".