### PR TITLE
fix circular dependency in Rake 10.X.X.

### DIFF
--- a/dist/exe.rake
+++ b/dist/exe.rake
@@ -1,48 +1,48 @@
+namespace 'exe' do
+  desc "build Windows exe package"
+  task 'build' => '^build' do
+    create_build_dir('exe') do |dir|
+      install_ruby_version = '2.2.2'
+      # create ./installers/
+      FileUtils.mkdir_p "installers"
+      installer_path = download_resource("http://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-#{install_ruby_version}.exe?direct")
+      FileUtils.cp installer_path, "installers/rubyinstaller.exe"
 
-desc "build Windows exe package"
-task 'exe:build' => :build do
-  create_build_dir('exe') do |dir|
-    install_ruby_version = '2.2.2'
-    # create ./installers/
-    FileUtils.mkdir_p "installers"
-    installer_path = download_resource("http://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-#{install_ruby_version}.exe?direct")
-    FileUtils.cp installer_path, "installers/rubyinstaller.exe"
+      variables = {
+        :version => version,
+        :basename => "td-#{version}",
+        :outdir => ".",
+        :install_ruby_version => install_ruby_version,
+      }
 
-    variables = {
-      :version => version,
-      :basename => "td-#{version}",
-      :outdir => ".",
-      :install_ruby_version => install_ruby_version,
-    }
-
-    # create ./td/
-    mkchdir("td") do
-      mkchdir('vendor/gems') do
-        install_use_gems(Dir.pwd)
+      # create ./td/
+      mkchdir("td") do
+        mkchdir('vendor/gems') do
+          install_use_gems(Dir.pwd)
+        end
+        install_resource 'exe/td', 'bin/td', 0755
+        install_erb_resource 'exe/td.bat', 'bin/td.bat', 0755, variables
+        install_resource 'exe/td-cmd.bat', 'td-cmd.bat', 0755
       end
-      install_resource 'exe/td', 'bin/td', 0755
-      install_erb_resource 'exe/td.bat', 'bin/td.bat', 0755, variables
-      install_resource 'exe/td-cmd.bat', 'td-cmd.bat', 0755
+
+      zip_files(project_root_path("pkg/td-update-exe-#{version}.zip"), 'td')
+
+      # create td.iss and run Inno Setup
+      install_erb_resource 'exe/td.iss', 'td.iss', 0644, variables
+
+      inno_dir = ENV["INNO_DIR"] || 'C:/Program Files (x86)/Inno Setup 5'
+      inno_bin = ENV["INNO_BIN"] || "#{inno_dir}/Compil32.exe"
+      puts "INNO_BIN: #{inno_bin}"
+
+      sh "\"#{inno_bin}\" /cc \"td.iss\""
+      FileUtils.cp "td-#{version}.exe", project_root_path("pkg/td-#{version}.exe")
     end
+  end
 
-    zip_files(project_root_path("pkg/td-update-exe-#{version}.zip"), 'td')
-
-    # create td.iss and run Inno Setup
-    install_erb_resource 'exe/td.iss', 'td.iss', 0644, variables
-
-    inno_dir = ENV["INNO_DIR"] || 'C:/Program Files (x86)/Inno Setup 5'
-    inno_bin = ENV["INNO_BIN"] || "#{inno_dir}/Compil32.exe"
-    puts "INNO_BIN: #{inno_bin}"
-
-    sh "\"#{inno_bin}\" /cc \"td.iss\""
-    FileUtils.cp "td-#{version}.exe", project_root_path("pkg/td-#{version}.exe")
+  desc "clean Windows exe package"
+  task "clean" do
+    FileUtils.rm_rf build_dir_path('exe')
+    FileUtils.rm_rf project_root_path("pkg/td-#{version}.exe")
+    FileUtils.rm_rf project_root_path("pkg/td-update-exe-#{version}.zip")
   end
 end
-
-desc "clean Windows exe package"
-task "exe:clean" do
-  FileUtils.rm_rf build_dir_path('exe')
-  FileUtils.rm_rf project_root_path("pkg/td-#{version}.exe")
-  FileUtils.rm_rf project_root_path("pkg/td-update-exe-#{version}.zip")
-end
-

--- a/dist/pkg.rake
+++ b/dist/pkg.rake
@@ -1,54 +1,54 @@
+namespace 'pkg' do
+  desc "build Mac OS X pkg package"
+  task 'build' => '^build' do
+    create_build_dir('pkg') do |dir|
+      FileUtils.mkdir_p "bundle"
+      FileUtils.mkdir_p "bundle/Resources"
+      FileUtils.mkdir_p "bundle/td-client.pkg"
+      FileUtils.mkdir_p "bundle/td-client.pkg"
 
-desc "build Mac OS X pkg package"
-task 'pkg:build' => :build do
-  create_build_dir('pkg') do |dir|
-    FileUtils.mkdir_p "bundle"
-    FileUtils.mkdir_p "bundle/Resources"
-    FileUtils.mkdir_p "bundle/td-client.pkg"
-    FileUtils.mkdir_p "bundle/td-client.pkg"
-
-    # create ./bundle/td-client.pkg/Payload
-    mkchdir('td-client.build') do
-      mkchdir('vendor/gems') do
-        install_use_gems(Dir.pwd)
+      # create ./bundle/td-client.pkg/Payload
+      mkchdir('td-client.build') do
+        mkchdir('vendor/gems') do
+          install_use_gems(Dir.pwd)
+        end
+        install_resource 'pkg/td', 'bin/td', 0755
+        sh "pax -wz -x cpio . > ../bundle/td-client.pkg/Payload"
       end
-      install_resource 'pkg/td', 'bin/td', 0755
-      sh "pax -wz -x cpio . > ../bundle/td-client.pkg/Payload"
+
+      zip_files(project_root_path("pkg/td-update-pkg-#{version}.zip"), 'td-client.build')
+
+      # create ./bundle/td-client.pkg/Bom
+      sh "mkbom -s td-client.build bundle/td-client.pkg/Bom"
+
+      # create ./bundle/td-client.pkg/Scripts/
+      install_resource 'pkg/postinstall', 'bundle/td-client.pkg/Scripts/postinstall', 0755
+
+      variables = {
+        :version => version,
+        :kbytes => `du -ks td-client.build | cut -f 1`.strip.to_i,
+        :num_files => `find td-client.build | wc -l`,
+      }
+
+      # create ./bundle/td-client.pkg/PackageInfo
+      install_erb_resource('pkg/PackageInfo.erb', 'bundle/td-client.pkg/PackageInfo', 0644, variables)
+
+      # create ./bundle/Distribution
+      install_erb_resource('pkg/Distribution.erb', 'bundle/Distribution', 0644, variables)
+
+      sh "pkgutil --expand #{project_root_path('dist/resources/pkg/ruby-2.0.0-p0.pkg')} ruby"
+      mv "ruby/ruby-2.0.0-p0.pkg", "bundle/ruby.pkg"
+
+      # create td-a.b.c.pkg
+      sh "pkgutil --flatten bundle td-#{version}.pkg"
+      FileUtils.cp "td-#{version}.pkg", project_root_path("pkg/td-#{version}.pkg")
     end
+  end
 
-    zip_files(project_root_path("pkg/td-update-pkg-#{version}.zip"), 'td-client.build')
-
-    # create ./bundle/td-client.pkg/Bom
-    sh "mkbom -s td-client.build bundle/td-client.pkg/Bom"
-
-    # create ./bundle/td-client.pkg/Scripts/
-    install_resource 'pkg/postinstall', 'bundle/td-client.pkg/Scripts/postinstall', 0755
-
-    variables = {
-      :version => version,
-      :kbytes => `du -ks td-client.build | cut -f 1`.strip.to_i,
-      :num_files => `find td-client.build | wc -l`,
-    }
-
-    # create ./bundle/td-client.pkg/PackageInfo
-    install_erb_resource('pkg/PackageInfo.erb', 'bundle/td-client.pkg/PackageInfo', 0644, variables)
-
-    # create ./bundle/Distribution
-    install_erb_resource('pkg/Distribution.erb', 'bundle/Distribution', 0644, variables)
-
-    sh "pkgutil --expand #{project_root_path('dist/resources/pkg/ruby-2.0.0-p0.pkg')} ruby"
-    mv "ruby/ruby-2.0.0-p0.pkg", "bundle/ruby.pkg"
-
-    # create td-a.b.c.pkg
-    sh "pkgutil --flatten bundle td-#{version}.pkg"
-    FileUtils.cp "td-#{version}.pkg", project_root_path("pkg/td-#{version}.pkg")
+  desc "clean Mac OS X pkg package"
+  task "clean" do
+    FileUtils.rm_rf build_dir_path('pkg')
+    FileUtils.rm_rf project_root_path("pkg/td-#{version}.pkg")
+    FileUtils.rm_rf project_root_path("pkg/td-update-pkg-#{version}.zip")
   end
 end
-
-desc "clean Mac OS X pkg package"
-task "pkg:clean" do
-  FileUtils.rm_rf build_dir_path('pkg')
-  FileUtils.rm_rf project_root_path("pkg/td-#{version}.pkg")
-  FileUtils.rm_rf project_root_path("pkg/td-update-pkg-#{version}.zip")
-end
-


### PR DESCRIPTION
fix circular dependency in Rake 10.X.X.

```
$ rake pkg:build
rake aborted!
Circular dependency detected: TOP => pkg:build => pkg:build

Tasks: TOP => pkg:build
(See full trace by running task with --trace)
```

see https://github.com/jimweirich/rake/issues/274#issuecomment-43280663