### PR TITLE
support `msgpack.gz` format in query command, and fix save gz format

### DIFF
--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -415,7 +415,7 @@ private
         indicator = Command::SizeBasedDownloadProgressIndicator.new(
           "NOTE: the job result is being written to #{output} in msgpack.gz format",
           job.result_size, 0.1, 1)
-        job.result_format('msgpack.gz', f) {|compr_size|
+        job.result_raw('msgpack.gz', f) {|compr_size|
           indicator.update(compr_size)
         }
         indicator.finish

--- a/lib/td/command/options.rb
+++ b/lib/td/command/options.rb
@@ -61,6 +61,7 @@ module Options
       yield(s)
     }
   end
+  module_function :write_format_option
 end # module Options
 end # module Command
 end # module TreasureData

--- a/lib/td/command/options.rb
+++ b/lib/td/command/options.rb
@@ -28,12 +28,6 @@ module Options
       opts[:output] = s
       opts[:format] ||= 'tsv'
     }
-    op.on('-f', '--format FORMAT', 'format of the result to write to the file (tsv, csv, json, msgpack, and msgpack.gz)') {|s|
-      unless ['tsv', 'csv', 'json', 'msgpack', 'msgpack.gz'].include?(s)
-        raise "Unknown format #{s.dump}. Supported formats are: tsv, csv, json, msgpack, and msgpack.gz"
-      end
-      opts[:format] = s
-    }
     op.on('-l', '--limit ROWS', 'limit the number of result rows shown when not outputting to file') {|s|
       unless s.to_i > 0
         raise "Invalid limit number. Must be a positive integer"
@@ -52,10 +46,21 @@ module Options
       opts[:render_opts][:null_expr] = s.to_s
     }
 
+    write_format_option(op) {|s| opts[:format] = s }
+
     # CAUTION: this opts is filled by op.cmd_parse
     opts
   end
 
+  def write_format_option(op)
+    op.on('-f', '--format FORMAT', 'format of the result to write to the file (tsv, csv, json, msgpack, and msgpack.gz)') {|s|
+      unless ['tsv', 'csv', 'json', 'msgpack', 'msgpack.gz'].include?(s)
+        raise "Unknown format #{s.dump}. Supported formats are: tsv, csv, json, msgpack, and msgpack.gz"
+      end
+
+      yield(s)
+    }
+  end
 end # module Options
 end # module Command
 end # module TreasureData

--- a/lib/td/command/query.rb
+++ b/lib/td/command/query.rb
@@ -1,3 +1,5 @@
+require 'td/command/options'
+
 module TreasureData
 module Command
 
@@ -34,12 +36,9 @@ module Command
       output = s
       format = 'tsv' if format.nil?
     }
-    op.on('-f', '--format FORMAT', 'format of the result to write to the file (tsv, csv, json or msgpack)') {|s|
-      unless ['tsv', 'csv', 'json', 'msgpack'].include?(s)
-        raise "Unknown format #{s.dump}. Supported format: tsv, csv, json, msgpack"
-      end
-      format = s
-    }
+
+    TreasureData::Command::Options.write_format_option(op) {|s| format = s }
+
     op.on('-r', '--result RESULT_URL', 'write result to the URL (see also result:create subcommand)',
                                        ' It is suggested for this option to be used with the -x / --exclude option to suppress printing',
                                        ' of the query result to stdout or -o / --output to dump the query result into a file.') {|s|

--- a/spec/td/command/job_spec.rb
+++ b/spec/td/command/job_spec.rb
@@ -22,7 +22,6 @@ module TreasureData::Command
           @result_size = 3
           @status = 'success'
         end
-        job.stub(:result_format) # for msgpack, msgpack.gz
         job
       end
 
@@ -73,6 +72,10 @@ module TreasureData::Command
         context "format: msgpack" do
           let(:format) { "msgpack" }
 
+          before do
+            job.stub(:result_format) # for msgpack
+          end
+
           it do
             FileUtils.should_receive(:mv).with(tempfile, file.path)
             subject
@@ -85,6 +88,10 @@ module TreasureData::Command
 
         context "format: msgpack.gz" do
           let(:format) { "msgpack.gz" }
+
+          before do
+            job.stub(:result_raw)    # for msgpack.gz
+          end
 
           it do
             FileUtils.should_receive(:mv).with(tempfile, file.path)


### PR DESCRIPTION
support `msgpack.gz` format in query command.

And, I found `td job:show -f msgpack.gz` is saved decompressed file.
So, I fix that save gz fromated file.

This need https://github.com/treasure-data/td-client-ruby/pull/58.