### PR TITLE
show query command result with retry

### DIFF
--- a/lib/td/command/query.rb
+++ b/lib/td/command/query.rb
@@ -142,7 +142,7 @@ module Command
 
     if wait
       wait_job(job, true)
-      $stdout.puts "Status     : #{job.status}"
+      $stdout.puts "Status      : #{job.status}"
       if job.success? && !exclude
         begin
           show_result_with_retry(job, output, limit, format, render_opts)

--- a/lib/td/command/query.rb
+++ b/lib/td/command/query.rb
@@ -144,9 +144,8 @@ module Command
       wait_job(job, true)
       $stdout.puts "Status     : #{job.status}"
       if job.success? && !exclude
-        $stdout.puts "Result     :"
         begin
-          show_result(job, output, limit, format, render_opts)
+          show_result_with_retry(job, output, limit, format, render_opts)
         rescue TreasureData::NotFoundError => e
         end
       end


### PR DESCRIPTION
`job:show` is retry when show result. But, `query -w` dosen't retry.
This pull request allow retry when `query -w`.