### PR TITLE
fix data format that return from td-client#bulk_load-history

### DIFF
--- a/lib/td/command/connector.rb
+++ b/lib/td/command/connector.rb
@@ -230,15 +230,15 @@ module Command
     client = get_client()
     rows = client.bulk_load_history(name).map { |e|
       {
-        :JobID => e.job_id,
-        :Status => e.status,
-        :Records => e.records,
+        :JobID => e['job_id'],
+        :Status => e['status'],
+        :Records => e['records'],
         # TODO: td-client-ruby should retuan only name
-        :Database => e.database['name'],
-        :Table => e.table['name'],
-        :Priority => e.priority,
-        :Started => Time.at(e.start_at),
-        :Duration => (e.end_at.nil? ? Time.now.to_i : e.end_at) - e.start_at,
+        :Database => e['database']['name'],
+        :Table => e['table']['name'],
+        :Priority => e['priority'],
+        :Started => Time.at(e['start_at']),
+        :Duration => (e['end_at'].nil? ? Time.now.to_i : e['end_at']) - e['start_at'],
       }
     }
     $stdout.puts cmd_render_table(rows, :fields => fields, :render_format => op.render_format)


### PR DESCRIPTION
`connector:history` was broken from 0.11.10.

It's support following commit.
https://github.com/treasure-data/td-client-ruby/commit/e5226f383c4ccffcb8b77b88989c33d3268d9af4
