### PR TITLE
connector::guess use flow format hash

### DIFF
--- a/lib/td/command/connector.rb
+++ b/lib/td/command/connector.rb
@@ -75,7 +75,7 @@ module Command
     if /\.json\z/ =~ out
       config_str = JSON.pretty_generate(job['config'])
     else
-      config_str = YAML.dump(job['config'])
+      config_str = config_to_yaml(job['config'])
     end
     File.open(out, 'w') do |f|
       f << config_str
@@ -284,6 +284,19 @@ private
     end
     nil
   end
+
+  def config_to_yaml(config)
+    config_str = ''
+    begin
+      require 'td/compact_format_yamler'
+      config_str = TreasureData::CompactFormatYamler.dump(config)
+    rescue
+      # NOTE fail back
+      config_str = YAML.dump(config)
+    end
+    config_str
+  end
+
 
   def prepare_bulkload_job_config(config_file)
     unless File.exist?(config_file)

--- a/lib/td/compact_format_yamler.rb
+++ b/lib/td/compact_format_yamler.rb
@@ -4,6 +4,13 @@ module TreasureData
   module CompactFormatYamler
     module Visitors
       class YAMLTree < Psych::Visitors::YAMLTree
+        # NOTE support 2.0 following
+        unless self.respond_to? :create
+          class << self
+            alias :create :new
+          end
+        end
+
         def visit_Hash o
           if o.class == ::Hash && o.values.all? {|v| v.kind_of?(Numeric) || v.kind_of?(String) || v.kind_of?(Symbol) }
             register(o, @emitter.start_mapping(nil, nil, true, Psych::Nodes::Mapping::FLOW))

--- a/lib/td/compact_format_yamler.rb
+++ b/lib/td/compact_format_yamler.rb
@@ -1,0 +1,34 @@
+require 'psych'
+
+module TreasureData
+  module CompactFormatYamler
+    module Visitors
+      class YAMLTree < Psych::Visitors::YAMLTree
+        def visit_Hash o
+          if o.class == ::Hash && o.values.all? {|v| v.kind_of?(Numeric) || v.kind_of?(String) || v.kind_of?(Symbol) }
+            register(o, @emitter.start_mapping(nil, nil, true, Psych::Nodes::Mapping::FLOW))
+
+            o.each do |k,v|
+              accept k
+              accept v
+            end
+            @emitter.end_mapping
+          else
+            super
+          end
+        end
+      end
+    end
+
+    def self.dump(o, io = nil, options = {})
+      if Hash === io
+        options = io
+        io = nil
+      end
+
+      visitor = ::TreasureData::CompactFormatYamler::Visitors::YAMLTree.create options
+      visitor << o
+      visitor.tree.yaml io, options
+    end
+  end
+end

--- a/spec/td/command/connector_spec.rb
+++ b/spec/td/command/connector_spec.rb
@@ -12,8 +12,8 @@ module TreasureData::Command
 
       describe 'guess plugins' do
         let(:guess_plugins) { %w(json query_string) }
-        let(:in_file)  { Tempfile.new('in.yml') }
-        let(:out_file) { Tempfile.new('out.yml') }
+        let(:in_file)  { Tempfile.new('in.yml').tap{|f| f.close } }
+        let(:out_file) { Tempfile.new('out.yml').tap{|f| f.close } }
         let(:option) {
           List::CommandParser.new("connector:guess", ["config"], [], nil, [in_file.path, '-o', out_file.path, '--guess', guess_plugins.join(',')], true)
         }

--- a/spec/td/compact_format_yamler_spec.rb
+++ b/spec/td/compact_format_yamler_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'td/compact_format_yamler'
+
+module TreasureData
+  describe TreasureData::CompactFormatYamler do
+    describe '.dump' do
+      let(:data) {
+        {
+          'a' => {
+            'b' => {
+              'c' => 1,
+              'd' => 'e'
+            },
+            'f' => [1, 2, 3]
+          }
+        }
+      }
+
+      let(:comapct_format_yaml) {
+        <<-EOS
+---
+a:
+  b: {c: 1, d: e}
+  f:
+  - 1
+  - 2
+  - 3
+        EOS
+      }
+
+      subject { TreasureData::CompactFormatYamler.dump data }
+
+      it 'use compact format for deepest Hash' do
+        expect(subject).to eq comapct_format_yaml
+      end
+    end
+  end
+end


### PR DESCRIPTION
ref #74 
I could not find the YAML library that can be used is compact format.
So, I implemented inheriting the psych.

---

```
# before
---
in:
  type: s3
  access_key_id:
  secret_access_key:
  bucket: 
  path_prefix: connector_issue_test
  decoders:
  - type: gzip
  parser:
    charset: UTF-8
    newline: CRLF
    type: csv
    delimiter: ","
    quote: "\""
    escape: "\""
    trim_if_not_quoted: false
    skip_header_lines: 1
    allow_extra_columns: false
    allow_optional_columns: false
    columns:
    - name: id
      type: long
    - name: " company"
      type: string
    - name: " customer"
      type: string
    - name: " created_at"
      type: timestamp
      format: "%Y-%m-%d %H:%M:%S"
filters: []
out:
  mode: append
```

```
# after
---
in:
  type: s3
  access_key_id: 
  secret_access_key: 
  bucket: 
  path_prefix: connector_issue_test
  decoders:
  - {type: gzip}
  parser:
    charset: UTF-8
    newline: CRLF
    type: csv
    delimiter: ","
    quote: "\""
    escape: "\""
    trim_if_not_quoted: false
    skip_header_lines: 1
    allow_extra_columns: false
    allow_optional_columns: false
    columns:
    - {name: id, type: long}
    - {name: " company", type: string}
    - {name: " customer", type: string}
    - {name: " created_at", type: timestamp, format: "%Y-%m-%d %H:%M:%S"}
filters: []
out: {mode: append}
```