### PR TITLE
more informative obsolute message for connector:guess

### DIFF
--- a/lib/td/command/connector.rb
+++ b/lib/td/command/connector.rb
@@ -36,6 +36,7 @@ module Command
       out ||= config_file
     else
       begin
+        $stdout.puts 'Command line option is obsoleted. You should use configuration file.'
         required('--access-id', id)
         required('--access-secret', secret)
         required('--source', source)


### PR DESCRIPTION
show obsolute message, if use command line option.

```
Command line option is obsoleted. You should use configuration file.
```