### PR TITLE
job:show and query support `--column-header` option with json format

### DIFF
--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -122,9 +122,9 @@ module Command
     end
 
     if render_opts[:header]
-      unless ['tsv', 'csv'].include?(format)
+      unless ['json', 'tsv', 'csv'].include?(format)
         raise ParameterConfigurationError,
-              "Option -c / --column-header is only supported with tsv and csv formats"
+              "Option -c / --column-header is only supported with json, tsv and csv formats"
       end
     end
 

--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -306,7 +306,15 @@ private
 
     case format
     when 'json'
-      write_result_for_json(job, output, tempfile, limit, render_opts) {|row| row }
+      if render_opts[:header] && job.hive_result_schema
+        headers = job.hive_result_schema.map {|name, _| name }
+
+        write_result_for_json(job, output, tempfile, limit, render_opts) {|row|
+          Hash[headers.zip(row)]
+        }
+      else
+        write_result_for_json(job, output, tempfile, limit, render_opts) {|row| row }
+      end
     when 'csv'
       require 'yajl'
       require 'csv'

--- a/lib/td/command/query.rb
+++ b/lib/td/command/query.rb
@@ -76,7 +76,7 @@ module Command
       end
       limit = s.to_i
     }
-    op.on('-c', '--column-header', 'output of the columns\' header when the schema is available for the table (only applies to tsv and csv formats)', TrueClass) {|b|
+    op.on('-c', '--column-header', 'output of the columns\' header when the schema is available for the table (only applies to json, tsv and csv formats)', TrueClass) {|b|
       render_opts[:header] = b
     }
     op.on('-x', '--exclude', 'do not automatically retrieve the job result', TrueClass) {|b|
@@ -115,9 +115,9 @@ module Command
     end
 
     if render_opts[:header]
-      unless ['tsv', 'csv'].include?(format)
+      unless ['tsv', 'csv', 'json'].include?(format)
         raise ParameterConfigurationError,
-              "Option -c / --column-header is only supported with tsv and csv formats"
+              "Option -c / --column-header is only supported with json, tsv and csv formats"
       end
     end
 
@@ -155,5 +155,3 @@ module Command
   require 'td/command/job'  # wait_job, job_priority_id_of
 end
 end
-
-

--- a/spec/td/command/job_spec.rb
+++ b/spec/td/command/job_spec.rb
@@ -146,7 +146,7 @@ module TreasureData::Command
 
           it 'supports json output' do
             command.send(:show_result, job, file, nil, 'json', { header: true })
-            File.read(file.path).should == %Q([[null,2.0,{"key":3}]])
+            File.read(file.path).should == %Q([{"c0":null,"c1":2.0,"v":{"key":3},"c3":null}])
           end
 
           it 'supports csv output' do


### PR DESCRIPTION
ref #118 

`td query` and `td job:show` render json with header name key . 

```
[{"code":200,"cnt":4981},
{"code":404,"cnt":17},
{"code":500,"cnt":2}]
```