### PR TITLE
fix api_backtrace nil case

### DIFF
--- a/lib/td/command/runner.rb
+++ b/lib/td/command/runner.rb
@@ -190,7 +190,7 @@ EOF
         show_backtrace "Error #{$!.class}: backtrace:", $!.backtrace
       end
 
-      if $!.respond_to? :api_backtrace
+      if $!.respond_to?(:api_backtrace) && $!.api_backtrace
         show_backtrace "Error backtrace from server:", $!.api_backtrace.split("\n")
       end
 


### PR DESCRIPTION
fix `ib/td/command/runner.rb:194:in `rescue in run': undefined method `split' for nil:NilClass (NoMethodError)`