### PR TITLE
Install symlink in /usr/local/bin

### DIFF
--- a/dist/resources/pkg/postinstall
+++ b/dist/resources/pkg/postinstall
@@ -1,5 +1,5 @@
 #!/bin/sh
-ln -sf /usr/local/td/bin/td /usr/bin/td
+ln -sf /usr/local/td/bin/td /usr/local/bin/td
 osascript -e '
 tell application "Terminal"
     activate


### PR DESCRIPTION
At least on OS X El Capitan it is hard to install something in /usr/bin.
And on other OSes, it is bad behavior to touch /usr/bin because it is
manged by OS distributor (OS itself and official package manager).
We, treasure data, should touch /usr/local.