### PR TITLE
path check regexp should check only the last entry

### DIFF
--- a/lib/td/updater.rb
+++ b/lib/td/updater.rb
@@ -53,7 +53,7 @@ module ModuleDefinition
   def get_client_version_file(path)
     td_gems = Dir[File.join(path, "vendor/gems/td-*")]
     td_gems.each { |td_gem|
-      if td_gem =~ /#{"#{Regexp.escape(path)}\/vendor\/gems\/td-\\d*.\\d*.\\d*"}/
+      if /[\/\\]td-\d+.\d+.\d+\z/ =~ td_gem
         return File.join(td_gem, "/lib/td/version.rb")
       end
     }


### PR DESCRIPTION
* Since the regexp checks the return value of Dir.glob, it doesn't need
  to check entries other than the last one.
* On windows path may be 8.3 short path name for example username,
  previous check may fail by it.