### PR TITLE
Use -Eutf-8 to specify ARGV as UTF-8

### DIFF
--- a/dist/resources/exe/td.bat
+++ b/dist/resources/exe/td.bat
@@ -5,9 +5,9 @@ if not "%~f0" == "~f0" goto WinNT
 goto Win9x
 
 :Win9x
-@"%~dp0\..\ruby-<%= install_ruby_version %>\bin\ruby.exe" "td" %1 %2 %3 %4 %5 %6 %7 %8 %9
+@"%~dp0\..\ruby-<%= install_ruby_version %>\bin\ruby.exe" -Eutf-8 "td" %1 %2 %3 %4 %5 %6 %7 %8 %9
 goto :EOF
 
 :WinNT
-@"%~dp0\..\ruby-<%= install_ruby_version %>\bin\ruby.exe" "%~dpn0" %*
+@"%~dp0\..\ruby-<%= install_ruby_version %>\bin\ruby.exe" -Eutf-8 "%~dpn0" %*
 goto :EOF


### PR DESCRIPTION
On Windows ARGV converts the result of GetCommandLineW() into the
locale encoding (through default external encoding ruby_set_argv),
even if lib/td/command/runner.rb has `Encoding.default_external = 'UTF-8'`,
because ARGV is set in the bootstrap phase.
-Eutf-8 resolves this.