### PR TITLE
Support dummy schedule

### DIFF
--- a/lib/td/command/sched.rb
+++ b/lib/td/command/sched.rb
@@ -116,7 +116,11 @@ module Command
       exit 1
     end
 
-    $stderr.puts "Schedule '#{name}' is created. It starts at #{first_time.localtime}."
+    if first_time
+      $stderr.puts "Schedule '#{name}' is created. It starts at #{first_time.localtime}."
+    else
+      $stderr.puts "Schedule '#{name}' is created, which never runs."
+    end
   end
 
   def sched_delete(op)


### PR DESCRIPTION
td-client-ruby 0.8.79's create_schedule may return nil
https://github.com/treasure-data/td-client-ruby/pull/78