### PR TITLE
Support `td query --domain-key=KEY`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
 gemfile:
   - Gemfile
 
-script: bundle exec rake spec
+script: bundle exec rake spec SPEC_OPTS="-fd"
 
 matrix:
   allow_failures:

--- a/lib/td/command/query.rb
+++ b/lib/td/command/query.rb
@@ -19,6 +19,7 @@ module Command
     limit = nil
     exclude = false
     pool_name = nil
+    domain_key = nil
 
     op.on('-d', '--database DB_NAME', 'use the database (required)') {|s|
       db_name = s
@@ -85,6 +86,9 @@ module Command
     op.on('-O', '--pool-name NAME', 'specify resource pool by name') {|s|
       pool_name = s
     }
+    op.on('--domain-key DOMAIN_KEY', 'optional user-provided unique ID. You can include this ID with your `create` request to ensure idempotence') {|s|
+      domain_key = s
+    }
 
     sql = op.cmd_parse
 
@@ -134,6 +138,7 @@ module Command
     opts = {}
     opts['type'] = type if type
     opts['pool_name'] = pool_name if pool_name
+    opts['domain_key'] = domain_key if domain_key
     job = client.query(db_name, sql, result_url, priority, retry_limit, opts)
 
     $stdout.puts "Job #{job.job_id} is queued."

--- a/lib/td/command/runner.rb
+++ b/lib/td/command/runner.rb
@@ -185,7 +185,7 @@ EOF
       #   => NotFoundError
       #   => AuthError
       if ![ParameterConfigurationError, BulkImportExecutionError, UpdateError, ImportError,
-            APIError, ForbiddenError, NotFoundError, AuthError].include?(e.class) ||
+            APIError, ForbiddenError, NotFoundError, AuthError, AlreadyExistsError].include?(e.class) ||
          !ENV['TD_TOOLBELT_DEBUG'].nil? || $verbose
         show_backtrace "Error #{$!.class}: backtrace:", $!.backtrace
       end

--- a/spec/td/command/query_spec.rb
+++ b/spec/td/command/query_spec.rb
@@ -1,0 +1,42 @@
+# encoding: utf-8
+
+require 'spec_helper'
+require 'td/command/common'
+require 'td/command/list'
+require 'td/command/query'
+require 'td/client'
+require 'tempfile'
+
+module TreasureData::Command
+  describe 'query commands' do
+    let :client do
+      double('client')
+    end
+    let :job do
+      double('job', job_id: 123)
+    end
+    let :command do
+      Class.new { include TreasureData::Command }.new
+    end
+    before do
+      allow(command).to receive(:get_client).and_return(client)
+      expect(client).to receive(:database).with('sample_datasets')
+    end
+
+    it 'accepts --domain-key' do
+      expect(client).to receive(:query).
+        with("sample_datasets", "SELECT 1;", nil, nil, nil, {"domain_key"=>"hoge"}).
+        and_return(job)
+      op = List::CommandParser.new("query", %w[query], %w[], nil, ['--domain-key=hoge', '-dsample_datasets', 'SELECT 1;'], false)
+      command.query(op)
+    end
+
+    it 'raises error if --domain-key is duplicated' do
+      expect(client).to receive(:query).
+        with("sample_datasets", "SELECT 1;", nil, nil, nil, {"domain_key"=>"hoge"}).
+        and_raise(::TreasureData::AlreadyExistsError.new('Query failed: domain_key has already been taken'))
+      op = List::CommandParser.new("query", %w[query], %w[], nil, ['--domain-key=hoge', '-dsample_datasets', 'SELECT 1;'], false)
+      expect{ command.query(op) }.to raise_error(TreasureData::AlreadyExistsError)
+    end
+  end
+end


### PR DESCRIPTION
"Domain key" is an optional user-provided unique ID.
Users can include this ID with your `create` request to ensure idempotence.