### PR TITLE
CLT-1096: Add an explanation for Google SSO users

### DIFF
--- a/lib/td/command/account.rb
+++ b/lib/td/command/account.rb
@@ -41,7 +41,7 @@ module Command
       end
     end
 
-    $stdout.puts "Enter your Treasure Data credentials."
+    $stdout.puts "Enter your Treasure Data credentials. For Google SSO user, please see https://docs.treasuredata.com/articles/command-line#google-sso-users"
     unless user_name
       begin
         $stdout.print "Email: "


### PR DESCRIPTION
This commit is for Google SSO user to know how to authorize td command. 
Google SSO users is not able to login via `td account`.
So, I would like to link the help.
https://docs.treasuredata.com/articles/command-line#google-sso-users