### PR TITLE
Deprecate Pig query engine

### DIFF
--- a/lib/td/command/query.rb
+++ b/lib/td/command/query.rb
@@ -63,7 +63,7 @@ module Command
     op.on('-q', '--query PATH', 'use file instead of inline query') {|s|
       query = File.open(s) { |f| f.read.strip }
     }
-    op.on('-T', '--type TYPE', 'set query type (hive, pig, presto)') {|s|
+    op.on('-T', '--type TYPE', 'set query type (hive, presto)') {|s|
       type = s.to_sym
     }
     op.on('--sampling DENOMINATOR', 'OBSOLETE - enable random sampling to reduce records 1/DENOMINATOR', Integer) {|i|

--- a/lib/td/command/sched.rb
+++ b/lib/td/command/sched.rb
@@ -76,7 +76,7 @@ module Command
     op.on('-R', '--retry COUNT', 'automatic retrying count', Integer) {|i|
       retry_limit = i
     }
-    op.on('-T', '--type TYPE', 'set query type (hive or pig)') {|s|
+    op.on('-T', '--type TYPE', 'set query type (hive)') {|s|
       type = s
     }
 
@@ -190,7 +190,7 @@ module Command
     op.on('-R', '--retry COUNT', 'automatic retrying count', Integer) {|i|
       retry_limit = i
     }
-    op.on('-T', '--type TYPE', 'set query type (hive or pig)') {|s|
+    op.on('-T', '--type TYPE', 'set query type (hive)') {|s|
       type = s
     }
 


### PR DESCRIPTION
Remove mentions of "pig" as a valid type for these commands:

* `td query`
* `td sched:create`
* `td sched:update`