### PR TITLE
Show help for workflow:reset --help

### DIFF
--- a/lib/td/command/workflow.rb
+++ b/lib/td/command/workflow.rb
@@ -68,6 +68,8 @@ module TreasureData
 
     # "Factory reset"
     def workflow_reset(op)
+      op.cmd_parse # to show help
+
       $stdout << 'Removing workflow module...'
       FileUtils.rm_rf digdag_dir
       $stdout.puts ' Done.'
@@ -75,6 +77,8 @@ module TreasureData
     end
 
     def workflow_version(op)
+      op.cmd_parse # to show help
+
       unless File.exists?(digdag_cli_path)
         $stderr.puts('Workflow module not yet installed.')
         return 1


### PR DESCRIPTION
and workflow:version --help.

Without this `td workflow:reset --help` will just remove work flow module.