### PR TITLE
Support workflow on aws tokyo

### DIFF
--- a/lib/td/command/workflow.rb
+++ b/lib/td/command/workflow.rb
@@ -26,13 +26,18 @@ module TreasureData
         env = {}
         digdag_config_path = File.join(wd, 'config')
         FileUtils.touch(digdag_config_path)
-        if Config.cl_apikey
+        workflow_endpoint = Config.workflow_endpoint
+
+        # In the future passing config to digdag should use environment variables
+        if Config.cl_apikey || workflow_endpoint != 'https://api-workflow.treasuredata.com'
           # If the user passes the apikey on the command line we cannot use the digdag td.conf plugin.
           # Instead, create a digdag configuration file with the endpoint and the specified apikey.
-          env['TD_CONFIG_PATH'] = nil
           apikey = TreasureData::Config.apikey
+          env['TD_CONFIG_PATH'] = nil
+          env['TREASURE_DATA_WORKFLOW_ENDPOINT'] = workflow_endpoint
+          env['TD_API_KEY'] = apikey
           File.write(digdag_config_path, [
-              'client.http.endpoint = https://api-workflow.treasuredata.com',
+              "client.http.endpoint = #{workflow_endpoint}",
               "client.http.headers.authorization = TD1 #{apikey}",
               "secrets.td.apikey = #{apikey}"
           ].join($/) + $/)

--- a/lib/td/config.rb
+++ b/lib/td/config.rb
@@ -160,6 +160,21 @@ class Config
     @@cl_endpoint = flag
   end
 
+  def self.workflow_endpoint
+    case self.endpoint.to_s.sub(%r[https?://], '')
+    when '', 'api.treasuredata.com'
+      'https://api-workflow.treasuredata.com'
+    when 'api-staging.treasuredata.com'
+      'https://api-staging-workflow.treasuredata.com'
+    when 'api.treasuredata.co.jp'
+      'https://api-workflow.treasuredata.co.jp'
+    when 'api-staging.treasuredata.co.jp'
+      'https://api-staging-workflow.treasuredata.co.jp'
+    else
+      raise ConfigError, "Workflow is not supported for '#{self.endpoint}'"
+    end
+  end
+
   # renders the apikey and endpoint options as a string for the helper commands
   def self.cl_options_string
     string = ""

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,15 @@ unless ENV['APPVEYOR']
   Coveralls.wear!('rails')
 end
 
+RSpec.configure do |config|
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
+end
+
 require 'td/command/runner'
 
 def execute_td(command_line)

--- a/spec/td/config_spec.rb
+++ b/spec/td/config_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'td/config'
+
+describe TreasureData::Config do
+  context 'workflow_endpoint' do
+    before { TreasureData::Config.endpoint = api_endpoint }
+    subject { TreasureData::Config.workflow_endpoint }
+    context 'api.treasuredata.com' do
+      context 'works without http schema' do
+        let(:api_endpoint){ 'api.treasuredata.com' }
+        it { is_expected.to eq 'https://api-workflow.treasuredata.com' }
+      end
+      context 'works with http schema' do
+        let(:api_endpoint){ 'http://api.treasuredata.com' }
+        it { is_expected.to eq 'ahttps://pi-workflow.treasuredata.com' }
+      end
+      context 'works with https schema' do
+        let(:api_endpoint){ 'https://api.treasuredata.com' }
+        it { is_expected.to eq 'ahttps://pi-workflow.treasuredata.com' }
+      end
+    end
+    context 'api.treasuredata.co.jp' do
+      let(:api_endpoint){ 'api.treasuredata.co.jp' }
+      it { is_expected.to eq 'ahttps://pi-workflow.treasuredata.co.jp' }
+    end
+    context 'api-staging.treasuredata.com' do
+      let(:api_endpoint){ 'api-staging.treasuredata.com' }
+      it { is_expected.to eq 'ahttps://pi-staging-workflow.treasuredata.com' }
+    end
+    context 'api-staging.treasuredata.co.jp' do
+      let(:api_endpoint){ 'api-staging.treasuredata.co.jp' }
+      it { is_expected.to eq 'ahttps://pi-staging-workflow.treasuredata.co.jp' }
+    end
+    context 'ybi.jp-east.idcfcloud.com' do
+      let(:api_endpoint){ 'ybi.jp-east.idcfcloud.com' }
+      it 'raise error' do
+        expect { subject }.to raise_error(TreasureData::ConfigError)
+      end
+    end
+  end
+end

--- a/spec/td/config_spec.rb
+++ b/spec/td/config_spec.rb
@@ -12,24 +12,24 @@ describe TreasureData::Config do
       end
       context 'works with http schema' do
         let(:api_endpoint){ 'http://api.treasuredata.com' }
-        it { is_expected.to eq 'ahttps://pi-workflow.treasuredata.com' }
+        it { is_expected.to eq 'https://api-workflow.treasuredata.com' }
       end
       context 'works with https schema' do
         let(:api_endpoint){ 'https://api.treasuredata.com' }
-        it { is_expected.to eq 'ahttps://pi-workflow.treasuredata.com' }
+        it { is_expected.to eq 'https://api-workflow.treasuredata.com' }
       end
     end
     context 'api.treasuredata.co.jp' do
       let(:api_endpoint){ 'api.treasuredata.co.jp' }
-      it { is_expected.to eq 'ahttps://pi-workflow.treasuredata.co.jp' }
+      it { is_expected.to eq 'https://api-workflow.treasuredata.co.jp' }
     end
     context 'api-staging.treasuredata.com' do
       let(:api_endpoint){ 'api-staging.treasuredata.com' }
-      it { is_expected.to eq 'ahttps://pi-staging-workflow.treasuredata.com' }
+      it { is_expected.to eq 'https://api-staging-workflow.treasuredata.com' }
     end
     context 'api-staging.treasuredata.co.jp' do
       let(:api_endpoint){ 'api-staging.treasuredata.co.jp' }
-      it { is_expected.to eq 'ahttps://pi-staging-workflow.treasuredata.co.jp' }
+      it { is_expected.to eq 'https://api-staging-workflow.treasuredata.co.jp' }
     end
     context 'ybi.jp-east.idcfcloud.com' do
       let(:api_endpoint){ 'ybi.jp-east.idcfcloud.com' }


### PR DESCRIPTION
Where you should review:
* TREASURE_DATA_WORKFLOW_ENDPOINT: naming
* TD_API_KEY: maybe this should be TREASURE_DATA_API_KEY but digdag doesn't support it