### PR TITLE
Pass td-api endpoint to digdag

### DIFF
--- a/lib/td/command/workflow.rb
+++ b/lib/td/command/workflow.rb
@@ -42,6 +42,7 @@ module TreasureData
               "secrets.td.apikey = #{apikey}"
           ].join($/) + $/)
           cmd << '-Dio.digdag.standards.td.secrets.enabled=false'
+          cmd << "-Dconfig.td.default_endpoint=#{Config.endpoint_domain}"
         else
           # Use the digdag td.conf plugin to configure wf api and apikey.
           env['TREASURE_DATA_CONFIG_PATH'] = Config.path

--- a/lib/td/config.rb
+++ b/lib/td/config.rb
@@ -152,6 +152,10 @@ class Config
     @@endpoint = endpoint
   end
 
+  def self.endpoint_domain
+    (self.endpoint || 'api.treasuredata.com').sub(%r[https?://], '')
+  end
+
   def self.cl_endpoint
     @@cl_endpoint
   end
@@ -161,8 +165,8 @@ class Config
   end
 
   def self.workflow_endpoint
-    case self.endpoint.to_s.sub(%r[https?://], '')
-    when '', 'api.treasuredata.com'
+    case self.endpoint_domain
+    when 'api.treasuredata.com'
       'https://api-workflow.treasuredata.com'
     when 'api-staging.treasuredata.com'
       'https://api-staging-workflow.treasuredata.com'


### PR DESCRIPTION
For `td workflow run foo.dig` whose dig file includes td operator,
digdag needs to call correct td-api endpoint which relates apikey,
but td command didn't pass it.