### PR TITLE
Use x64 binary

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,17 @@
 == 2018-04-17 version 0.16.1
 
-
+* Use x64 binary #206
+  td-toolbelt on Windows is migrated to x64 version.
+  Now this doesn't work on 32bit version of Windows.
 
 == 2018-04-14 version 0.16.0
 
-* bump version#205
+* Add retry_limit and priority to export:result #203
+* Remove auto td update #204
+  Now `td update` needs manually executed to update td CLI.
+* bump toolbelt version #205
+  v0.16 doesn't support upgrade from v0.15 or prior by `td update`.
+  To use v0.16, please download td-toolbelt package and install with it.
 
 == 2018-04-04 version 0.15.9
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+== 2018-04-17 version 0.16.1
+
+
+
+== 2018-04-14 version 0.16.0
+
+* bump version#205
+
 == 2018-04-04 version 0.15.9
 
 * Use td-client-ruby 1.0.6

--- a/dist/exe.rake
+++ b/dist/exe.rake
@@ -5,7 +5,7 @@ namespace 'exe' do
       install_ruby_version = '2.4.4'
       # create ./installers/
       FileUtils.mkdir_p "installers"
-      installer_path = project_root_path("dist/resources/exe/rubyinstaller-2.4.4-1-x86.exe")
+      installer_path = project_root_path("dist/resources/exe/rubyinstaller-2.4.4-1-x64.exe")
       FileUtils.cp installer_path, "installers/rubyinstaller.exe"
 
       variables = {

--- a/spec/td/updater_spec.rb
+++ b/spec/td/updater_spec.rb
@@ -8,7 +8,7 @@ require 'logger'
 
 module TreasureData::Updater
 
- %w(x86_64-darwin14 i386-mingw32).each do |platform|
+ %w(x86_64-darwin14 x64-mingw32).each do |platform|
     describe "RUBY_PLATFORM is '#{platform}'" do
       before do
         stub_const('RUBY_PLATFORM', platform)


### PR DESCRIPTION
MSYS2's mingw32 environment doesn't work well; it show following error:
    180 [main] ruby 3156 child_info_fork::abort: address space needed by 'console.so' (0x3F0000) is already occupied

I decide to use mingw64 from v0.16.