### PR TITLE
Remove deprecated gem specification

### DIFF
--- a/td.gemspec
+++ b/td.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |gem|
   gem.version               = TreasureData::TOOLBELT_VERSION
   gem.authors               = ["Treasure Data, Inc."]
   gem.email                 = "support@treasure-data.com"
-  gem.has_rdoc              = false
   gem.files                 = `git ls-files`.split("\n").select { |f| !f.start_with?('dist') }
   gem.test_files            = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.executables           = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
This commit will suppress such warnings:

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from td/td.gemspec:13.
```

Ref: https://github.com/rubygems/rubygems/pull/2214/files#diff-05477d38d75c98664b0e7dec6eb73b45R2035