### PR TITLE
Bump minimum rubyzip version to 1.3.0

### DIFF
--- a/td.gemspec
+++ b/td.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "parallel", "~> 1.8"
   gem.add_dependency "td-client", ">= 1.0.6", "< 2"
   gem.add_dependency "td-logger", ">= 0.3.21", "< 2"
-  gem.add_dependency "rubyzip", ">= 1.2.1"
+  gem.add_dependency "rubyzip", ">= 1.3.0"
   gem.add_dependency "zip-zip", "~> 0.3"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
Rubyzip < 1.3.0 is affected by CVE-2019-16892.

Even when this gem isn't directly affected by the CVE some automatic
vulnerability scanners can mark the gem as unsafe because of the
dependency version.

Related: https://github.com/rubyzip/rubyzip/pull/403

This closes https://github.com/treasure-data/td/issues/221