### PR TITLE
CLT-1474: Use HTTPS as default for downloading digdag module

### DIFF
--- a/lib/td/command/workflow.rb
+++ b/lib/td/command/workflow.rb
@@ -137,7 +137,7 @@ module TreasureData
     end
 
     def digdag_base_url(version=nil)
-      base = 'http://toolbelt.treasure-data.com/digdag'
+      base = 'https://toolbelt.treasure-data.com/digdag'
       if version.to_s == ''
         base
       else
@@ -218,7 +218,7 @@ module TreasureData
 
     private
     def jre_url
-      base_url = ENV.fetch('TD_WF_JRE_BASE_URL', 'http://toolbelt.treasuredata.com/digdag/jdk/')
+      base_url = ENV.fetch('TD_WF_JRE_BASE_URL', 'https://toolbelt.treasuredata.com/digdag/jdk/')
       "#{base_url}#{jre_archive}"
     end
 

--- a/spec/td/command/workflow_spec.rb
+++ b/spec/td/command/workflow_spec.rb
@@ -161,7 +161,7 @@ EOF
         expect(TreasureData::Updater).to_not have_received(:stream_fetch).with(
             %r{/java/}, instance_of(File))
         expect(TreasureData::Updater).to have_received(:stream_fetch).with(
-            'http://toolbelt.treasure-data.com/digdag?user=test%40example.com', instance_of(File))
+            'https://toolbelt.treasure-data.com/digdag?user=test%40example.com', instance_of(File))
       end
 
       it 'installs java + digdag and can run a workflow' do
@@ -180,7 +180,7 @@ EOF
         expect(stdout_io.string).to include 'Downloading workflow module'
         expect(File).to exist(File.join(ENV[home_env], '.td', 'digdag', 'digdag'))
         expect(TreasureData::Updater).to have_received(:stream_fetch).with(
-            'http://toolbelt.treasure-data.com/digdag?user=test%40example.com', instance_of(File))
+            'https://toolbelt.treasure-data.com/digdag?user=test%40example.com', instance_of(File))
 
         # Check that java and digdag is not re-installed
         stdout_io.truncate(0)
@@ -228,7 +228,7 @@ EOF
           expect(TreasureData::Updater).to_not have_received(:stream_fetch).with(
               %r{/java/}, instance_of(File))
           expect(TreasureData::Updater).to have_received(:stream_fetch).with(
-              'http://toolbelt.treasure-data.com/digdag?user=test%40example.com', instance_of(File))
+              'https://toolbelt.treasure-data.com/digdag?user=test%40example.com', instance_of(File))
 
           # Check that digdag is not re-installed
           stdout_io.truncate(0)
@@ -250,7 +250,7 @@ EOF
           expect(stdout_io.string).to include 'Downloading workflow module'
           expect(File).to exist(File.join(ENV[home_env], '.td', 'digdag', 'digdag'))
           expect(TreasureData::Updater).to have_received(:stream_fetch).with(
-              'http://toolbelt.treasure-data.com/digdag', instance_of(File))
+              'https://toolbelt.treasure-data.com/digdag', instance_of(File))
         }
       end
 


### PR DESCRIPTION
This change use HTTPS as default for downloading digdag module

```
$ TD_TOOLBELT_DEBUG=1 td wf
Workflow module not yet installed, download now? [Y/n]
y
redirect 'https://toolbelt.treasuredata.com/digdag/jdk/mac_x64' to 'https://d3hq3slxjftf62.cloudfront.net/java/zulu8.17.0.3-jdk8.0.102-macosx_x64.zip'...                                                   
redirect 'https://toolbelt.treasuredata.com/digdag/jdk/mac_x64' to 'https://d3hq3slxjftf62.cloudfront.net/java/zulu8.17.0.3-jdk8.0.102-macosx_x64.zip'... 
Downloading Java...: done                                                                                                                                                                                   
Installing Java... done
redirect 'https://toolbelt.treasure-data.com/digdag?user=takahashi%40treasure-data.com' to 'https://dl.digdag.io/digdag-latest'...                                                                          
redirect 'https://dl.digdag.io/digdag-latest' to 'https://dl.bintray.com/digdag/maven/digdag-0.9.39.jar'... 
redirect 'https://dl.bintray.com/digdag/maven/digdag-0.9.39.jar' to 'https://d29vzk4ow07wi7.cloudfront.net/dbe3ab5e2d512e39111feaeb8e2859b980a33d7bb3b61456d9f19f4b155ad228?response-content-disposition=attachment%3Bfilename%3D%22digdag-0.9.39.jar%22&Policy=eyJTdGF0ZW1lbnQiOiBbeyJSZXNvdXJjZSI6Imh0dHAqOi8vZDI5dnprNG93MDd3aTcuY2xvdWRmcm9udC5uZXQvZGJlM2FiNWUyZDUxMmUzOTExMWZlYWViOGUyODU5Yjk4MGEzM2Q3YmIzYjYxNDU2ZDlmMTlmNGIxNTVhZDIyOD9yZXNwb25zZS1jb250ZW50LWRpc3Bvc2l0aW9uPWF0dGFjaG1lbnQlM0JmaWxlbmFtZSUzRCUyMmRpZ2RhZy0wLjkuMzkuamFyJTIyIiwiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6eyJBV1M6RXBvY2hUaW1lIjoxNTczNDQzMDQ3fSwiSXBBZGRyZXNzIjp7IkFXUzpTb3VyY2VJcCI6IjAuMC4wLjAvMCJ9fX1dfQ__&Signature=iSHjEHjZGkePyFzfretJFKRhPplI7DpApEvF2-aip0aR2b38Ssks92J5ELnyQfbFtblYoa-1~QPRzWZscXh7eVBq64bG9DqD7ZyEw6rhZ3iU6JGeebscIlJSm-hQGKQ-BHHgAtTsRgbCksOmPHXuATtaVdkJzXIRhDkIoi5PrNwc2~BUdMRAQ5hu6udaqg0fdtyJ2AVDvwzpsd-gnJEgMlHHpHp1b0d-wAeaUFSpfTnY8yjdEQeZLgBMilxisuKDSZ76-ID2ZJki1x75DUGSpGXCHDaUuAGU69zVKctVcolVtYacv-YVKRQ~2klxH9jes056M-n5fSVKkT5hT~DbzQ__&Key-Pair-Id=APKAIFKFWOMXM2UMTSFA'... 
Downloading workflow module...: done                                                                                                                                                                        
Installing workflow module... done
["/Users/toru/.td/digdag/jre/bin/java", "-Dio.digdag.cli.programName=td workflow", "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-Xverify:none", "-Dio.digdag.standards.td.client-configurator.enabled=true", "-jar", "/Users/toru/.td/digdag/digdag"]
2019-11-11 12:18:56 +0900: Digdag v0.9.39
Usage: td workflow <command> [options...]
  Local-mode commands:
    init <dir>                         create a new workflow project
    r[un] <workflow.dig>               run a workflow
    c[heck]                            show workflow definitions
    sched[uler]                        run a scheduler server
    migrate (run|check)                migrate database
    selfupdate                         update cli to the latest version

  Server-mode commands:
    server                             start server

  Client-mode commands:
    push <project-name>                create and upload a new revision
    download <project-name>            pull an uploaded revision
    start <project-name> <name>        start a new session attempt of a workflow
    retry <attempt-id>                 retry a session
    kill <attempt-id>                  kill a running session attempt
    backfill <schedule-id>             start sessions of a schedule for past times
    backfill <project-name> <name>     start sessions of a schedule for past times
    reschedule <schedule-id>           skip sessions of a schedule to a future time
    reschedule <project-name> <name>   skip sessions of a schedule to a future time
    log <attempt-id>                   show logs of a session attempt
    projects [name]                    show projects
    workflows [project-name] [name]    show registered workflow definitions
    schedules                          show registered schedules
    disable <schedule-id>              disable a workflow schedule
    disable <project-name>             disable all workflow schedules in a project
    disable <project-name> <name>      disable a workflow schedule
    enable <schedule-id>               enable a workflow schedule
    enable <project-name>              enable all workflow schedules in a project
    enable <project-name> <name>       enable a workflow schedule
    sessions                           show sessions for all workflows
    sessions <project-name>            show sessions for all workflows in a project
    sessions <project-name> <name>     show sessions for a workflow
    session  <session-id>              show a single session
    attempts                           show attempts for all sessions
    attempts <session-id>              show attempts for a session
    attempt  <attempt-id>              show a single attempt
    tasks <attempt-id>                 show tasks of a session attempt
    delete <project-name>              delete a project
    secrets --project <project-name>   manage secrets
    version                            show client and server version

  Options:
    -L, --log PATH                   output log messages to a file (default: -)
    -l, --log-level LEVEL            log level (error, warn, info, debug or trace)
    -X KEY=VALUE                     add a performance system config
    -c, --config PATH.properties     Configuration file (default: /Users/toru/.config/digdag/config)
    --version                        show client version

  Client options:
    -e, --endpoint URL               Server endpoint (default: http://127.0.0.1:65432)
    -H, --header  KEY=VALUE          Additional headers
    --disable-version-check          Disable server version check
    --disable-cert-validation        Disable certificate verification
    --basic-auth <user:pass>         Add an Authorization header with the provided username and password

Use `<command> --help` to see detailed usage of a command.
TD-0159:~ toru$ td wf version
2019-11-11 12:19:23 +0900: Digdag v0.9.39
Client version: 0.9.39
Server version: 0.9.37
```