### PR TITLE
add -Dclient.http.disable_direct_download=true for private connection

### DIFF
--- a/lib/td/command/workflow.rb
+++ b/lib/td/command/workflow.rb
@@ -43,6 +43,9 @@ module TreasureData
           ].join($/) + $/)
           cmd << '-Dio.digdag.standards.td.secrets.enabled=false'
           cmd << "-Dconfig.td.default_endpoint=#{Config.endpoint_domain}"
+          if workflow_endpoint.match(/\.connect\./i)
+            cmd << '-Dclient.http.disable_direct_download=true'
+          end
         else
           # Use the digdag td.conf plugin to configure wf api and apikey.
           env['TREASURE_DATA_CONFIG_PATH'] = Config.path

--- a/td.gemspec
+++ b/td.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "parallel", "~> 1.8"
   gem.add_dependency "td-client", ">= 1.0.6", "< 2"
   gem.add_dependency "td-logger", ">= 0.3.21", "< 2"
-  gem.add_dependency "rubyzip", ">= 1.3.0"
+  gem.add_dependency "rubyzip", "~> 1.3.0"
   gem.add_dependency "zip-zip", "~> 0.3"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
add -Dclient.http.disable_direct_download=true command line argument if workflow server endpoint matches with /\.connect\./. 