### PR TITLE
Support recent java versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: ruby
 
-jdk:
-  - openjdk8
-
 rvm:
   - 2.1.10
   - 2.2.10

--- a/lib/td/command/workflow.rb
+++ b/lib/td/command/workflow.rb
@@ -246,14 +246,20 @@ EOF
         return false
       end
       if output =~ /openjdk version/ or output =~ /java version/
-        m = output.match(/version "(\d+)\.(\d+)\.(\d+)(?:_(\d+))"/)
+        m = output.match(/version "(\d+)\.(\d+)\.(\d+)(?:_(\d+))?"/)
         if not m or m.size < 4
           return false
         end
-        # Check for at least Java 8. Let digdag itself verify revision.
         major = m[1].to_i
         minor = m[2].to_i
-        if major < 1 or minor < 8
+        # Check for at least Java 8. Let digdag itself verify revision.
+        if major < 1
+          return false
+        elsif major == 1 # suppose the version style: 1.8.10_52 (JDK8 and before)
+          if minor < 8
+            return false
+          end
+        elsif major < 9 # suppose the version style: 11.0.2
           return false
         end
       end


### PR DESCRIPTION
The existing code for Java versions supposes `1.8.0_56` style format.
But currently, latest LTS Java version format is `11.0.2`, so it doesn't work correctly.

This change is to fix that problem.