### PR TITLE
Fix bug of the value to assign

### DIFF
--- a/lib/td/command/runner.rb
+++ b/lib/td/command/runner.rb
@@ -149,7 +149,7 @@ EOF
         Config.cl_endpoint = true
       end
       if import_endpoint
-        Config.import_endpoint = endpoint
+        Config.import_endpoint = import_endpoint
         Config.cl_import_endpoint = true
       end
       if insecure


### PR DESCRIPTION
The previous change #226 had a critical bug for `--import-endpoint` option to assign wrong value.
This change is to fix that.

The version with this change is actually working correctly on my laptop...