### PR TITLE
Update Import/Workflow Endpoint Configurations

### DIFF
--- a/lib/td/command/account.rb
+++ b/lib/td/command/account.rb
@@ -93,7 +93,7 @@ module Command
 
     $stdout.puts "Authenticated successfully."
 
-    conf ||= Config.new
+    conf ||= Config::ConfigFile.new
     conf["account.user"] = user_name
     conf["account.apikey"] = client.apikey
     conf['account.endpoint'] = endpoint if endpoint

--- a/lib/td/command/apikey.rb
+++ b/lib/td/command/apikey.rb
@@ -50,7 +50,7 @@ module Command
       end
     end
 
-    conf ||= Config.new
+    conf ||= Config::ConfigFile.new
     conf.delete("account.user")
     conf["account.apikey"] = apikey
     conf.save

--- a/lib/td/command/runner.rb
+++ b/lib/td/command/runner.rb
@@ -1,41 +1,41 @@
 module TreasureData
-module Command
+  module Command
 
-class Runner
-  def initialize
-    @config_path = nil
-    @apikey = nil
-    @endpoint = nil
-    @import_endpoint = nil
-    @prog_name = nil
-    @insecure = false
-  end
+    class Runner
+      def initialize
+        @config_path = nil
+        @apikey = nil
+        @endpoint = nil
+        @import_endpoint = nil
+        @prog_name = nil
+        @insecure = false
+      end
 
-  attr_accessor :apikey, :endpoint, :import_endpoint, :config_path, :prog_name, :insecure
+      attr_accessor :apikey, :endpoint, :import_endpoint, :config_path, :prog_name, :insecure
 
-  def run(argv=ARGV)
-    require 'td/version'
-    require 'td/compat_core'
-    require 'optparse'
+      def run(argv=ARGV)
+        require 'td/version'
+        require 'td/compat_core'
+        require 'optparse'
 
-    $prog = @prog_name || File.basename($0)
+        $prog = @prog_name || File.basename($0)
 
-    op = OptionParser.new
-    op.version = TOOLBELT_VERSION
-    op.banner = <<EOF
+        op = OptionParser.new
+        op.version = TOOLBELT_VERSION
+        op.banner = <<EOF
 usage: #{$prog} [options] COMMAND [args]
 
 options:
 EOF
 
-    op.summary_indent = "  "
+        op.summary_indent = "  "
 
-    (class << self;self;end).module_eval do
-      define_method(:usage) do |errmsg|
-        require 'td/command/list'
-        $stdout.puts op.to_s
-        $stdout.puts ""
-        $stdout.puts <<EOF
+        (class << self;self;end).module_eval do
+          define_method(:usage) do |errmsg|
+            require 'td/command/list'
+            $stdout.puts op.to_s
+            $stdout.puts ""
+            $stdout.puts <<EOF
 Basic commands:
 
   db             # create/delete/list databases
@@ -60,184 +60,184 @@ Additional commands:
 
 Type 'td help COMMAND' for more information on a specific command.
 EOF
-        if errmsg
-          $stdout.puts "Error: #{errmsg}"
-          return 1
-        else
-          return 0
+            if errmsg
+              $stdout.puts "Error: #{errmsg}"
+              return 1
+            else
+              return 0
+            end
+          end
         end
-      end
-    end
 
-    # there local vars are loaded with the values of the options below
-    # here they are preloaded with the defaults
-    config_path = @config_path
-    apikey = @apikey
-    endpoint = @endpoint
-    import_endpoint = @import_endpoint || @endpoint
-    insecure = nil
-    $verbose = false
-    #$debug = false
-    retry_post_requests = false
+        # there local vars are loaded with the values of the options below
+        # here they are preloaded with the defaults
+        config_path = @config_path
+        apikey = @apikey
+        endpoint = @endpoint
+        import_endpoint = @import_endpoint || @endpoint
+        insecure = nil
+        $verbose = false
+        #$debug = false
+        retry_post_requests = false
 
-    op.on('-c', '--config PATH', "path to the configuration file (default: ~/.td/td.conf)") {|s|
-      config_path = s
-    }
+        op.on('-c', '--config PATH', "path to the configuration file (default: ~/.td/td.conf)") {|s|
+          config_path = s
+        }
 
-    op.on('-k', '--apikey KEY', "use this API key instead of reading the config file") {|s|
-      apikey = s
-    }
+        op.on('-k', '--apikey KEY', "use this API key instead of reading the config file") {|s|
+          apikey = s
+        }
 
-    op.on('-e', '--endpoint API_SERVER', "specify the URL for API server to use (default: https://api.treasuredata.com)." ,
-                                         "  The URL must contain a scheme (http:// or https:// prefix) to be valid.",
-                                         "  Valid IPv4 addresses are accepted as well in place of the host name.") {|e|
-      require 'td/command/common'
-      Command.validate_api_endpoint(e)
-      endpoint = e
-    }
+        op.on('-e', '--endpoint API_SERVER', "specify the URL for API server to use (default: https://api.treasuredata.com)." ,
+              "  The URL must contain a scheme (http:// or https:// prefix) to be valid.",
+              "  Valid IPv4 addresses are accepted as well in place of the host name.") {|e|
+          require 'td/command/common'
+          Command.validate_api_endpoint(e)
+          endpoint = e
+        }
 
-    op.on('--import-endpoint API_IMPORT_SERVER', "specify the URL for API Import server to use (default: https://api-import.treasuredata.com).") { |e|
-      require 'td/command/common'
-      Command.validate_api_endpoint(e)
-      import_endpoint = e
-    }
+        op.on('--import-endpoint API_IMPORT_SERVER', "specify the URL for API Import server to use (default: https://api-import.treasuredata.com).") { |e|
+          require 'td/command/common'
+          Command.validate_api_endpoint(e)
+          import_endpoint = e
+        }
 
-    op.on('--insecure', "Insecure access: disable SSL (enabled by default)") {|b|
-      insecure = true
-    }
+        op.on('--insecure', "Insecure access: disable SSL (enabled by default)") {|b|
+          insecure = true
+        }
 
-    op.on('-v', '--verbose', "verbose mode", TrueClass) {|b|
-      $verbose = b
-    }
+        op.on('-v', '--verbose', "verbose mode", TrueClass) {|b|
+          $verbose = b
+        }
 
-    #op.on('-d', '--debug', "debug mode", TrueClass) {|b|
-    #	$debug = b
-    #}
+        #op.on('-d', '--debug', "debug mode", TrueClass) {|b|
+        #	$debug = b
+        #}
 
-    op.on('-h', '--help', "show help") {
-      return usage nil
-    }
+        op.on('-h', '--help', "show help") {
+          return usage nil
+        }
 
-    op.on('-r', '--retry-post-requests', "retry on failed post requests.",
-                                         "Warning: can cause resource duplication, such as duplicated job submissions.",
-                                         TrueClass) {|b|
-      retry_post_requests = b
-    }
+        op.on('-r', '--retry-post-requests', "retry on failed post requests.",
+              "Warning: can cause resource duplication, such as duplicated job submissions.",
+              TrueClass) {|b|
+          retry_post_requests = b
+        }
 
-    op.on('--version', "show version") {
-      $stdout.puts op.version
-      return 0
-    }
+        op.on('--version', "show version") {
+          $stdout.puts op.version
+          return 0
+        }
 
-    begin
-      op.order!(argv)
-      return usage nil if argv.empty?
-      cmd = argv.shift
+        begin
+          op.order!(argv)
+          return usage nil if argv.empty?
+          cmd = argv.shift
 
-      # NOTE: these information are loaded from by each command through
-      #       'TreasureData::Command::get_client' from 'lib/td/command/common.rb'
-      require 'td/config'
-      if config_path
-        Config.path = config_path
-      end
-      if apikey
-        Config.apikey = apikey
-        Config.cl_apikey = true
-      end
-      if endpoint
-        Config.endpoint = endpoint
-        Config.cl_endpoint = true
-      end
-      if import_endpoint
-        Config.import_endpoint = import_endpoint
-        Config.cl_import_endpoint = true
-      end
-      if insecure
-        Config.secure = false
-      end
-      if retry_post_requests
-        Config.retry_post_requests = true
-      end
-    rescue
-      return usage $!.to_s
-    end
+          # NOTE: these information are loaded from by each command through
+          #       'TreasureData::Command::get_client' from 'lib/td/command/common.rb'
+          require 'td/config'
+          if config_path
+            Config.path = config_path
+          end
+          if apikey
+            Config.apikey = apikey
+            Config.cl_apikey = true
+          end
+          if endpoint
+            Config.endpoint = endpoint
+            Config.cl_endpoint = true
+          end
+          if import_endpoint
+            Config.import_endpoint = import_endpoint
+            Config.cl_import_endpoint = true
+          end
+          if insecure
+            Config.secure = false
+          end
+          if retry_post_requests
+            Config.retry_post_requests = true
+          end
+        rescue
+          return usage $!.to_s
+        end
 
-    require 'td/command/list'
-    if defined?(Encoding)
-      #Encoding.default_internal = 'UTF-8' if Encoding.respond_to?(:default_internal)
-      Encoding.default_external = 'UTF-8' if Encoding.respond_to?(:default_external)
-    end
+        require 'td/command/list'
+        if defined?(Encoding)
+          #Encoding.default_internal = 'UTF-8' if Encoding.respond_to?(:default_internal)
+          Encoding.default_external = 'UTF-8' if Encoding.respond_to?(:default_external)
+        end
 
-    method, cmd_req_connectivity = Command::List.get_method(cmd)
-    unless method
-      $stderr.puts "'#{cmd}' is not a td command. Run '#{$prog}' to show the list."
-      Command::List.show_guess(cmd)
-      return 1
-    end
+        method, cmd_req_connectivity = Command::List.get_method(cmd)
+        unless method
+          $stderr.puts "'#{cmd}' is not a td command. Run '#{$prog}' to show the list."
+          Command::List.show_guess(cmd)
+          return 1
+        end
 
-    status = nil
-    begin
-      # test the connectivity with the API endpoint
-      if cmd_req_connectivity && Config.cl_endpoint
-        Command.test_api_endpoint(Config.endpoint)
-      end
-      status = method.call(argv)
-    rescue ConfigError
-      $stderr.puts "TreasureData account is not configured yet."
-      $stderr.puts "Run '#{$prog} account' first."
-    rescue => e
-      # known exceptions are rendered as simple error messages unless the
-      # TD_TOOLBELT_DEBUG variable is set or the -v / --verbose option is used.
-      # List of known exceptions:
-      #   => ParameterConfigurationError
-      #   => BulkImportExecutionError
-      #   => UpUpdateError
-      #   => ImportError
-      require 'td/client/api'
-      #   => APIError
-      #   => ForbiddenError
-      #   => NotFoundError
-      #   => AuthError
-      if ![ParameterConfigurationError, BulkImportExecutionError, UpdateError, ImportError,
-            APIError, ForbiddenError, NotFoundError, AuthError, AlreadyExistsError, WorkflowError].include?(e.class) ||
-         !ENV['TD_TOOLBELT_DEBUG'].nil? || $verbose
-        show_backtrace "Error #{$!.class}: backtrace:", $!.backtrace
-      end
+        status = nil
+        begin
+          # test the connectivity with the API endpoint
+          if cmd_req_connectivity && Config.cl_endpoint
+            Command.test_api_endpoint(Config.endpoint)
+          end
+          status = method.call(argv)
+        rescue ConfigError
+          $stderr.puts "TreasureData account is not configured yet."
+          $stderr.puts "Run '#{$prog} account' first."
+        rescue => e
+          # known exceptions are rendered as simple error messages unless the
+          # TD_TOOLBELT_DEBUG variable is set or the -v / --verbose option is used.
+          # List of known exceptions:
+          #   => ParameterConfigurationError
+          #   => BulkImportExecutionError
+          #   => UpUpdateError
+          #   => ImportError
+          require 'td/client/api'
+          #   => APIError
+          #   => ForbiddenError
+          #   => NotFoundError
+          #   => AuthError
+          if ![ParameterConfigurationError, BulkImportExecutionError, UpdateError, ImportError,
+               APIError, ForbiddenError, NotFoundError, AuthError, AlreadyExistsError, WorkflowError].include?(e.class) ||
+             !ENV['TD_TOOLBELT_DEBUG'].nil? || $verbose
+            show_backtrace "Error #{$!.class}: backtrace:", $!.backtrace
+          end
 
-      if $!.respond_to?(:api_backtrace) && $!.api_backtrace
-        show_backtrace "Error backtrace from server:", $!.api_backtrace.split("\n")
-      end
+          if $!.respond_to?(:api_backtrace) && $!.api_backtrace
+            show_backtrace "Error backtrace from server:", $!.api_backtrace.split("\n")
+          end
 
-      $stdout.print "Error: "
-      if [ForbiddenError, NotFoundError, AuthError].include?(e.class)
-        $stdout.print "#{e.class} - "
-      end
-      $stdout.puts $!.to_s
+          $stdout.print "Error: "
+          if [ForbiddenError, NotFoundError, AuthError].include?(e.class)
+            $stdout.print "#{e.class} - "
+          end
+          $stdout.puts $!.to_s
 
-      require 'socket'
-      if e.is_a?(::SocketError)
-        $stderr.puts <<EOS
+          require 'socket'
+          if e.is_a?(::SocketError)
+            $stderr.puts <<EOS
 
 Network dependent error occurred.
 If you want to use td command through a proxy,
 please set HTTP_PROXY environment variable (e.g. export HTTP_PROXY="host:port")
 EOS
+          end
+          return 1
+        end
+        return (status.is_a? Integer) ? status : 0
       end
-      return 1
-    end
-    return (status.is_a? Integer) ? status : 0
-  end
 
-  private
+      private
 
-  def show_backtrace(message, backtrace)
-    $stderr.puts message
-    backtrace.each {|bt|
-      $stderr.puts "  #{bt}"
-    }
-    $stdout.puts ""
-  end
-end # class Runner
+      def show_backtrace(message, backtrace)
+        $stderr.puts message
+        backtrace.each {|bt|
+          $stderr.puts "  #{bt}"
+        }
+        $stdout.puts ""
+      end
+    end # class Runner
 
-end # module Command
+  end # module Command
 end # module TreasureData

--- a/lib/td/command/runner.rb
+++ b/lib/td/command/runner.rb
@@ -7,11 +7,12 @@ module TreasureData
         @apikey = nil
         @endpoint = nil
         @import_endpoint = nil
+        @workflow_endpoint = nil
         @prog_name = nil
         @insecure = false
       end
 
-      attr_accessor :apikey, :endpoint, :import_endpoint, :config_path, :prog_name, :insecure
+      attr_accessor :apikey, :endpoint, :import_endpoint, :workflow_endpoint, :config_path, :prog_name, :insecure
 
       def run(argv=ARGV)
         require 'td/version'
@@ -74,7 +75,8 @@ EOF
         config_path = @config_path
         apikey = @apikey
         endpoint = @endpoint
-        import_endpoint = @import_endpoint || @endpoint
+        import_endpoint = @import_endpoint
+        workflow_endpoint = @workflow_endpoint
         insecure = nil
         $verbose = false
         #$debug = false
@@ -96,10 +98,16 @@ EOF
           endpoint = e
         }
 
-        op.on('--import-endpoint API_IMPORT_SERVER', "specify the URL for API Import server to use (default: https://api-import.treasuredata.com).") { |e|
+        op.on('--import-endpoint IMPORT_SERVER', "specify the URL for Import server to use (default: https://api-import.treasuredata.com).") { |e|
           require 'td/command/common'
           Command.validate_api_endpoint(e)
           import_endpoint = e
+        }
+
+        op.on('--workflow-endpoint WORKFLOW_SERVER', "specify the URL for Workflow server to use (default: https://api-workflow.treasuredata.com).") { |e|
+          require 'td/command/common'
+          Command.validate_api_endpoint(e)
+          workflow_endpoint = e
         }
 
         op.on('--insecure', "Insecure access: disable SSL (enabled by default)") {|b|
@@ -142,15 +150,15 @@ EOF
           end
           if apikey
             Config.apikey = apikey
-            Config.cl_apikey = true
           end
           if endpoint
             Config.endpoint = endpoint
-            Config.cl_endpoint = true
           end
           if import_endpoint
             Config.import_endpoint = import_endpoint
-            Config.cl_import_endpoint = true
+          end
+          if workflow_endpoint
+            Config.workflow_endpoint = workflow_endpoint
           end
           if insecure
             Config.secure = false

--- a/lib/td/command/server.rb
+++ b/lib/td/command/server.rb
@@ -26,7 +26,7 @@ module Command
     begin
       conf = Config.read
     rescue ConfigError
-      conf = Config.new
+      conf = Config::ConfigFile.new
     end
     conf["account.endpoint"] = endpoint
     conf.save

--- a/lib/td/command/workflow.rb
+++ b/lib/td/command/workflow.rb
@@ -42,7 +42,7 @@ module TreasureData
               "secrets.td.apikey = #{apikey}"
           ].join($/) + $/)
           cmd << '-Dio.digdag.standards.td.secrets.enabled=false'
-          cmd << "-Dconfig.td.default_endpoint=#{Config.endpoint_domain}"
+          cmd << "-Dconfig.td.default_endpoint=#{Config.endpoint_hostname(Config.endpoint)}"
           if workflow_endpoint.match(/\.connect\./i)
             cmd << '-Dclient.http.disable_direct_download=true'
           end

--- a/lib/td/config.rb
+++ b/lib/td/config.rb
@@ -1,205 +1,197 @@
-
 module TreasureData
-
-
-class ConfigError < StandardError
-end
-
-class ConfigNotFoundError < ConfigError
-end
-
-class ConfigParseError < ConfigError
-end
-
-
-class Config
-  # class variables
-  @@path = ENV['TREASURE_DATA_CONFIG_PATH'] || ENV['TD_CONFIG_PATH'] || File.join(ENV['HOME'], '.td', 'td.conf')
-  @@apikey = ENV['TREASURE_DATA_API_KEY'] || ENV['TD_API_KEY']
-  @@apikey = nil if @@apikey == ""
-  @@cl_apikey = false # flag to indicate whether an apikey has been provided through the command-line
-  @@endpoint = ENV['TREASURE_DATA_API_SERVER'] || ENV['TD_API_SERVER']
-  @@endpoint = nil if @@endpoint == ""
-  @@cl_endpoint = false # flag to indicate whether an endpoint has been provided through the command-line
-  @@import_endpoint = ENV['TREASURE_DATA_API_IMPORT_SERVER'] || ENV['TD_API_IMPORT_SERVER']
-  @@import_endpoint = nil if @@endpoint == ""
-  @@cl_import_endpoint = false # flag to indicate whether an endpoint has been provided through the command-line option
-  @@secure = true
-  @@retry_post_requests = false
-
-  def initialize
-    @path = nil
-    @conf = {}   # section.key = val
+  class ConfigError < StandardError
   end
 
-  def self.read(path=Config.path, create=false)
-    new.read(path)
+  class ConfigNotFoundError < ConfigError
   end
 
-  def [](cate_key)
-    @conf[cate_key]
+  class ConfigParseError < ConfigError
   end
 
-  def []=(cate_key, val)
-    @conf[cate_key] = val
-  end
+  class Config
+    # class variables
+    @@path = ENV['TREASURE_DATA_CONFIG_PATH'] || ENV['TD_CONFIG_PATH'] || File.join(ENV['HOME'], '.td', 'td.conf')
+    @@apikey = ENV['TREASURE_DATA_API_KEY'] || ENV['TD_API_KEY']
+    @@apikey = nil if @@apikey == ""
+    @@cl_apikey = false # flag to indicate whether an apikey has been provided through the command-line
+    @@endpoint = ENV['TREASURE_DATA_API_SERVER'] || ENV['TD_API_SERVER']
+    @@endpoint = nil if @@endpoint == ""
+    @@cl_endpoint = false # flag to indicate whether an endpoint has been provided through the command-line
+    @@import_endpoint = ENV['TREASURE_DATA_API_IMPORT_SERVER'] || ENV['TD_API_IMPORT_SERVER']
+    @@import_endpoint = nil if @@endpoint == ""
+    @@cl_import_endpoint = false # flag to indicate whether an endpoint has been provided through the command-line option
+    @@secure = true
+    @@retry_post_requests = false
 
-  def delete(cate_key)
-    @conf.delete(cate_key)
-  end
-
-  def read(path=@path)
-    @path = path
-    begin
-      data = File.read(@path)
-    rescue
-      e = ConfigNotFoundError.new($!.to_s)
-      e.set_backtrace($!.backtrace)
-      raise e
+    def initialize
+      @path = nil
+      @conf = {}   # section.key = val
     end
 
-    section = ""
+    def self.read(path=Config.path, create=false)
+      new.read(path)
+    end
 
-    data.each_line {|line|
-      line.strip!
-      case line
-      when /^#/
-        next
-      when /\[(.+)\]/
-        section = $~[1]
-      when /^(\w+)\s*=\s*(.+?)\s*$/
-        key = $~[1]
-        val = $~[2]
-        @conf["#{section}.#{key}"] = val
-      else
-        raise ConfigParseError, "invalid config line '#{line}' at #{@path}"
+    def [](cate_key)
+      @conf[cate_key]
+    end
+
+    def []=(cate_key, val)
+      @conf[cate_key] = val
+    end
+
+    def delete(cate_key)
+      @conf.delete(cate_key)
+    end
+
+    def read(path=@path)
+      @path = path
+      begin
+        data = File.read(@path)
+      rescue
+        e = ConfigNotFoundError.new($!.to_s)
+        e.set_backtrace($!.backtrace)
+        raise e
       end
-    }
 
-    self
-  end
+      section = ""
 
-  def save(path=@path||Config.path)
-    @path = path
-    write
-  end
+      data.each_line {|line|
+        line.strip!
+        case line
+        when /^#/
+          next
+        when /\[(.+)\]/
+          section = $~[1]
+        when /^(\w+)\s*=\s*(.+?)\s*$/
+          key = $~[1]
+          val = $~[2]
+          @conf["#{section}.#{key}"] = val
+        else
+          raise ConfigParseError, "invalid config line '#{line}' at #{@path}"
+        end
+      }
 
-  private
-  def write
-    require 'fileutils'
-    FileUtils.mkdir_p File.dirname(@path)
-    File.open(@path, "w") {|f|
-      @conf.keys.map {|cate_key|
-        cate_key.split('.', 2)
-      }.zip(@conf.values).group_by {|(section,key), val|
-        section
-      }.each {|section,cate_key_vals|
-        f.puts "[#{section}]"
-        cate_key_vals.each {|(section,key), val|
-          f.puts "  #{key} = #{val}"
+      self
+    end
+
+    def save(path=@path||Config.path)
+      @path = path
+      write
+    end
+
+    private
+    def write
+      require 'fileutils'
+      FileUtils.mkdir_p File.dirname(@path)
+      File.open(@path, "w") {|f|
+        @conf.keys.map {|cate_key|
+          cate_key.split('.', 2)
+        }.zip(@conf.values).group_by {|(section,key), val|
+          section
+        }.each {|section,cate_key_vals|
+          f.puts "[#{section}]"
+          cate_key_vals.each {|(section,key), val|
+            f.puts "  #{key} = #{val}"
+          }
         }
       }
-    }
-  end
-
-
-  def self.path
-    @@path
-  end
-
-  def self.path=(path)
-    @@path = path
-  end
-
-
-  def self.secure
-    @@secure
-  end
-
-  def self.secure=(secure)
-    @@secure = secure
-  end
-
-
-  def self.retry_post_requests
-    @@retry_post_requests
-  end
-
-  def self.retry_post_requests=(retry_post_requests)
-    @@retry_post_requests = retry_post_requests
-  end
-
-
-  def self.apikey
-    @@apikey || Config.read['account.apikey']
-  end
-
-  def self.apikey=(apikey)
-    @@apikey = apikey
-  end
-
-  def self.cl_apikey
-    @@cl_apikey
-  end
-
-  def self.cl_apikey=(flag)
-    @@cl_apikey = flag
-  end
-
-
-  def self.endpoint
-    @@endpoint || Config.read['account.endpoint']
-  end
-
-  def self.endpoint=(endpoint)
-    @@endpoint = endpoint
-  end
-
-  def self.endpoint_domain
-    (self.endpoint || 'api.treasuredata.com').sub(%r[https?://], '')
-  end
-
-  def self.cl_endpoint
-    @@cl_endpoint
-  end
-
-  def self.cl_endpoint=(flag)
-    @@cl_endpoint = flag
-  end
-
-  def self.import_endpoint
-    @@import_endpoint || Config.read['account.import_endpoint']
-  end
-
-  def self.import_endpoint=(endpoint)
-    @@import_endpoint = endpoint
-  end
-
-  def self.cl_import_endpoint
-    @@cl_import_endpoint
-  end
-
-  def self.cl_import_endpoint=(flag)
-    @@cl_import_endpoint = flag
-  end
-
-  def self.workflow_endpoint
-    case self.endpoint_domain
-    when /\Aapi(-(?:staging|development))?(-[a-z0-9]+)?\.(connect\.)?(eu01\.)?treasuredata\.(com|co\.jp)\z/i
-      "https://api#{$1}-workflow#{$2}.#{$3}#{$4}treasuredata.#{$5}"
-    else
-      raise ConfigError, "Workflow is not supported for '#{self.endpoint}'"
     end
-  end
 
-  # renders the apikey and endpoint options as a string for the helper commands
-  def self.cl_options_string
-    string = ""
-    string += "-k #{@@apikey} " if @@cl_apikey
-    string += "-e #{@@endpoint} " if @@cl_endpoint
-    string += "--import-endpoint #{@@import_endpoint} " if @@cl_import_endpoint
-    string
-  end
+    def self.path
+      @@path
+    end
 
-end # class Config
+    def self.path=(path)
+      @@path = path
+    end
+
+
+    def self.secure
+      @@secure
+    end
+
+    def self.secure=(secure)
+      @@secure = secure
+    end
+
+    def self.retry_post_requests
+      @@retry_post_requests
+    end
+
+    def self.retry_post_requests=(retry_post_requests)
+      @@retry_post_requests = retry_post_requests
+    end
+
+    def self.apikey
+      @@apikey || Config.read['account.apikey']
+    end
+
+    def self.apikey=(apikey)
+      @@apikey = apikey
+    end
+
+    def self.cl_apikey
+      @@cl_apikey
+    end
+
+    def self.cl_apikey=(flag)
+      @@cl_apikey = flag
+    end
+
+    def self.endpoint
+      @@endpoint || Config.read['account.endpoint']
+    end
+
+    def self.endpoint=(endpoint)
+      @@endpoint = endpoint
+    end
+
+    def self.endpoint_domain
+      (self.endpoint || 'api.treasuredata.com').sub(%r[https?://], '')
+    end
+
+    def self.cl_endpoint
+      @@cl_endpoint
+    end
+
+    def self.cl_endpoint=(flag)
+      @@cl_endpoint = flag
+    end
+
+    def self.import_endpoint
+      @@import_endpoint || Config.read['account.import_endpoint']
+    end
+
+    def self.import_endpoint=(endpoint)
+      @@import_endpoint = endpoint
+    end
+
+    def self.cl_import_endpoint
+      @@cl_import_endpoint
+    end
+
+    def self.cl_import_endpoint=(flag)
+      @@cl_import_endpoint = flag
+    end
+
+    def self.workflow_endpoint
+      case self.endpoint_domain
+      when /\Aapi(-(?:staging|development))?(-[a-z0-9]+)?\.(connect\.)?(eu01\.)?treasuredata\.(com|co\.jp)\z/i
+        "https://api#{$1}-workflow#{$2}.#{$3}#{$4}treasuredata.#{$5}"
+      else
+        raise ConfigError, "Workflow is not supported for '#{self.endpoint}'"
+      end
+    end
+
+    # renders the apikey and endpoint options as a string for the helper commands
+    def self.cl_options_string
+      string = ""
+      string += "-k #{@@apikey} " if @@cl_apikey
+      string += "-e #{@@endpoint} " if @@cl_endpoint
+      string += "--import-endpoint #{@@import_endpoint} " if @@cl_import_endpoint
+      string
+    end
+
+  end # class Config
 end # module TreasureData

--- a/lib/td/config.rb
+++ b/lib/td/config.rb
@@ -11,6 +11,11 @@ module TreasureData
   class Config
     # class variables
     @@path = ENV['TREASURE_DATA_CONFIG_PATH'] || ENV['TD_CONFIG_PATH'] || File.join(ENV['HOME'], '.td', 'td.conf')
+
+    def self.read(path=Config.path, create=false)
+      ConfigFile.new(path)
+    end
+
     @@apikey = ENV['TREASURE_DATA_API_KEY'] || ENV['TD_API_KEY']
     @@apikey = nil if @@apikey == ""
     @@cl_apikey = false # flag to indicate whether an apikey has been provided through the command-line
@@ -22,81 +27,6 @@ module TreasureData
     @@cl_import_endpoint = false # flag to indicate whether an endpoint has been provided through the command-line option
     @@secure = true
     @@retry_post_requests = false
-
-    def initialize
-      @path = nil
-      @conf = {}   # section.key = val
-    end
-
-    def self.read(path=Config.path, create=false)
-      new.read(path)
-    end
-
-    def [](cate_key)
-      @conf[cate_key]
-    end
-
-    def []=(cate_key, val)
-      @conf[cate_key] = val
-    end
-
-    def delete(cate_key)
-      @conf.delete(cate_key)
-    end
-
-    def read(path=@path)
-      @path = path
-      begin
-        data = File.read(@path)
-      rescue
-        e = ConfigNotFoundError.new($!.to_s)
-        e.set_backtrace($!.backtrace)
-        raise e
-      end
-
-      section = ""
-
-      data.each_line {|line|
-        line.strip!
-        case line
-        when /^#/
-          next
-        when /\[(.+)\]/
-          section = $~[1]
-        when /^(\w+)\s*=\s*(.+?)\s*$/
-          key = $~[1]
-          val = $~[2]
-          @conf["#{section}.#{key}"] = val
-        else
-          raise ConfigParseError, "invalid config line '#{line}' at #{@path}"
-        end
-      }
-
-      self
-    end
-
-    def save(path=@path||Config.path)
-      @path = path
-      write
-    end
-
-    private
-    def write
-      require 'fileutils'
-      FileUtils.mkdir_p File.dirname(@path)
-      File.open(@path, "w") {|f|
-        @conf.keys.map {|cate_key|
-          cate_key.split('.', 2)
-        }.zip(@conf.values).group_by {|(section,key), val|
-          section
-        }.each {|section,cate_key_vals|
-          f.puts "[#{section}]"
-          cate_key_vals.each {|(section,key), val|
-            f.puts "  #{key} = #{val}"
-          }
-        }
-      }
-    end
 
     def self.path
       @@path
@@ -193,5 +123,78 @@ module TreasureData
       string
     end
 
+    class ConfigFile
+      def initialize(path=nil)
+        @path = path
+        @conf = {}   # section.key = val
+        read if path
+      end
+
+      def [](cate_key)
+        @conf[cate_key]
+      end
+
+      def []=(cate_key, val)
+        @conf[cate_key] = val
+      end
+
+      def delete(cate_key)
+        @conf.delete(cate_key)
+      end
+
+      def read(path=@path)
+        @path = path
+        begin
+          data = File.read(@path)
+        rescue
+          e = ConfigNotFoundError.new($!.to_s)
+          e.set_backtrace($!.backtrace)
+          raise e
+        end
+
+        section = ""
+
+        data.each_line {|line|
+          line.strip!
+          case line
+          when /^#/
+            next
+          when /\[(.+)\]/
+            section = $~[1]
+          when /^(\w+)\s*=\s*(.+?)\s*$/
+            key = $~[1]
+            val = $~[2]
+            @conf["#{section}.#{key}"] = val
+          else
+            raise ConfigParseError, "invalid config line '#{line}' at #{@path}"
+          end
+        }
+
+        self
+      end
+
+      def save(path=@path||Config.path)
+        @path = path
+        write
+      end
+
+      private
+      def write
+        require 'fileutils'
+        FileUtils.mkdir_p File.dirname(@path)
+        File.open(@path, "w") {|f|
+          @conf.keys.map {|cate_key|
+            cate_key.split('.', 2)
+          }.zip(@conf.values).group_by {|(section,key), val|
+            section
+          }.each {|section,cate_key_vals|
+            f.puts "[#{section}]"
+            cate_key_vals.each {|(section,key), val|
+              f.puts "  #{key} = #{val}"
+            }
+          }
+        }
+      end
+    end
   end # class Config
 end # module TreasureData

--- a/spec/td/command/workflow_spec.rb
+++ b/spec/td/command/workflow_spec.rb
@@ -329,7 +329,7 @@ EOF
   describe 'verify argument with mock' do
     let(:command) { Class.new { include TreasureData::Command }.new }
     let(:empty_option) { List::CommandParser.new("workflow", [], [], nil, [], true) }
-    let(:td_config){ TreasureData::Config.new }
+    let(:td_config){ TreasureData::Config::ConfigFile.new }
     let(:workflow_config){ Hash.new }
     let(:digdag_env){ Hash.new }
     let(:config_path){ nil }
@@ -343,11 +343,9 @@ EOF
       end
       if apikey
         TreasureData::Config.apikey = apikey
-        TreasureData::Config.cl_apikey = true
       end
       if endpoint
         TreasureData::Config.endpoint = endpoint
-        TreasureData::Config.cl_endpoint = true
       end
       command_args.clear
 
@@ -388,11 +386,16 @@ EOF
       let (:endpoint){ 'https://api.treasuredata.com' }
       it 'uses td.conf' do
         apikey = '1/deadbeaf'
-        TreasureData::Config.apikey = apikey # emulate to load from config file
-        op = List::CommandParser.new("workflow", [], [], nil, ['version'], true)
-        command.workflow(op, false, false)
-        expect(workflow_config).to eq({})
-        expect(digdag_env['TREASURE_DATA_WORKFLOW_ENDPOINT']).to be_nil
+        begin
+          ENV['TD_API_KEY'] = apikey
+          # TreasureData::Config.apikey = apikey # emulate to load from config file
+          op = List::CommandParser.new("workflow", [], [], nil, ['version'], true)
+          command.workflow(op, false, false)
+          expect(workflow_config).to eq({})
+          expect(digdag_env['TREASURE_DATA_WORKFLOW_ENDPOINT']).to be_nil
+        ensure
+          ENV.delete('TD_API_KEY')
+        end
       end
     end
     context 'endpoint: https://api.treasuredata.co.jp' do

--- a/spec/td/config_spec.rb
+++ b/spec/td/config_spec.rb
@@ -3,6 +3,25 @@ require 'tempfile'
 require 'td/config'
 
 describe TreasureData::Config do
+  context 'import_endpoint' do
+    before { TreasureData::Config.endpoint = api_endpoint }
+    subject { TreasureData::Config.import_endpoint }
+    context 'api.treasuredata.com' do
+      context 'works without schema' do
+        let(:api_endpoint){ 'api.treasuredata.com' }
+        it { is_expected.to eq 'https://api-import.treasuredata.com' }
+      end
+      context 'works with port number' do
+        let(:api_endpoint){ 'api.treasuredata.com:443' }
+        it { is_expected.to eq 'https://api-import.treasuredata.com' }
+      end
+      context 'works with https schema' do
+        let(:api_endpoint){ 'https://api.treasuredata.com' }
+        it { is_expected.to eq 'https://api-import.treasuredata.com' }
+      end
+    end
+  end
+
   context 'workflow_endpoint' do
     before { TreasureData::Config.endpoint = api_endpoint }
     subject { TreasureData::Config.workflow_endpoint }
@@ -85,8 +104,7 @@ foo=bar
 
         f.close
 
-        config = TreasureData::Config.new
-        config.read(f.path)
+        config = TreasureData::Config.read(f.path)
 
         expect(config["section1.key"]).to eq "val"
         expect(config["section1.foo"]).to eq "bar"


### PR DESCRIPTION
To have default values supposed from default endpoint value, and also to allow to override those endpoints via command-line options.

In order to realize those things, I added some internal classes. Because the former way to manage configuration values requires to add many class variables and methods (like `cl_*`), and it is really messy & uncontrollable.
So, this change is a little larger than I expected. I want to hear the reviewers' comments.