### PR TITLE
Update error message when running `table:list` to import only DB

### DIFF
--- a/lib/td/command/table.rb
+++ b/lib/td/command/table.rb
@@ -171,7 +171,7 @@ module Command
     if rows.empty?
       if db_name
         if databases.first.permission == :import_only
-          $stderr.puts "Database '#{db_name}' is import only, cannot list or create tables."
+          $stderr.puts "Database '#{db_name}' is import only, cannot list."
         else
           $stderr.puts "Database '#{db_name}' has no tables."
           $stderr.puts "Use '#{$prog} " + Config.cl_options_string + "table:create <db> <table>' to create a table."


### PR DESCRIPTION
I updated an error message which is ouput as running `td table:list` to an import-only database.

As executing `table:list` command, `td` outputs `cannot list or create tables`:

```
% td table:list akito_import_only
0 rows in set
Database 'akito_import_only' is import only, cannot list or create tables.
```

However, creating a new table was succeeded though the database is import-only like below:

```
% td table:create akito_import_only samples
Table 'akito_import_only.samples' is created.
```

Therefore, I cut "or create tables" from the former error message since it would be misleading and the command was `td table:list` but not `td table:create`.

If we output `cannot list or create tables` as before, we might need to restrict users from creating new tables to import-only tables because we are able to create new tables now.

```
% td --version
0.16.8
```