### PR TITLE
Update Workflow endpoint pattern to support ap02

### DIFF
--- a/lib/td/config.rb
+++ b/lib/td/config.rb
@@ -185,7 +185,7 @@ class Config
 
   def self.workflow_endpoint
     case self.endpoint_domain
-    when /\Aapi(-(?:staging|development))?(-[a-z0-9]+)?\.(connect\.)?(eu01\.)?treasuredata\.(com|co\.jp)\z/i
+    when /\Aapi(-(?:staging|development))?(-[a-z0-9]+)?\.(connect\.)?((?:eu01|ap02)\.)?treasuredata\.(com|co\.jp)\z/i
       "https://api#{$1}-workflow#{$2}.#{$3}#{$4}treasuredata.#{$5}"
     else
       raise ConfigError, "Workflow is not supported for '#{self.endpoint}'"

--- a/spec/td/config_spec.rb
+++ b/spec/td/config_spec.rb
@@ -28,6 +28,10 @@ describe TreasureData::Config do
       let(:api_endpoint){ 'api.eu01.treasuredata.com' }
       it { is_expected.to eq 'https://api-workflow.eu01.treasuredata.com' }
     end
+    context 'api.ap02.treasuredata.com' do
+      let(:api_endpoint){ 'api.ap02.treasuredata.com' }
+      it { is_expected.to eq 'https://api-workflow.ap02.treasuredata.com' }
+    end
 
     context 'api-hoge.connect.treasuredata.com' do
       let(:api_endpoint){ 'api-hoge.connect.treasuredata.com' }
@@ -50,6 +54,10 @@ describe TreasureData::Config do
       let(:api_endpoint){ 'api-staging.eu01.treasuredata.com' }
       it { is_expected.to eq 'https://api-staging-workflow.eu01.treasuredata.com' }
     end
+    context 'api-staging.ap02.treasuredata.com' do
+      let(:api_endpoint){ 'api-staging.ap02.treasuredata.com' }
+      it { is_expected.to eq 'https://api-staging-workflow.ap02.treasuredata.com' }
+    end
 
     context 'api-development.treasuredata.com' do
       let(:api_endpoint){ 'api-development.treasuredata.com' }
@@ -62,6 +70,10 @@ describe TreasureData::Config do
     context 'api-development.eu01.treasuredata.com' do
       let(:api_endpoint){ 'api-development.eu01.treasuredata.com' }
       it { is_expected.to eq 'https://api-development-workflow.eu01.treasuredata.com' }
+    end
+    context 'api-development.ap02.treasuredata.com' do
+      let(:api_endpoint){ 'api-development.ap02.treasuredata.com' }
+      it { is_expected.to eq 'https://api-development-workflow.ap02.treasuredata.com' }
     end
 
     context 'ybi.jp-east.idcfcloud.com' do


### PR DESCRIPTION
- [x]  Update Workflow URL endpoint regex pattern to support api endpoint for region `ap02`
- [x]  Test the pattern resolves `https://api.ap02.treasuredata.com` to `https://api-workflow.ap02.treasuredata.com` correctly. Do the same for `production` and `eu01`.
- [x]  Test the the workflow api call to region `ap02` successfully
