### PR TITLE
Revise TD docs urls

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -6,9 +6,9 @@
 This CUI utility wraps the {Ruby Client Library td-client-ruby}[https://github.com/treasure-data/td-client-ruby]
 to interact with the REST API in managing databases and jobs on the Treasure Data Cloud.
 
-For more info about Treasure Data, see <http://treasure-data.com/>.
+For more info about Treasure Data, see <https://www.treasuredata.com>.
 
-For full documentation see <https://support.treasuredata.com/hc/en-us>.
+For full documentation see <https://tddocs.atlassian.net/wiki/spaces/PD/overview>.
 
 = Getting Started
 
@@ -71,7 +71,7 @@ The Bulk Import CLI is downloaded automatically at the first call to any of the 
 need internet connectivity in order to fetch the Bulk Import CLI JAR file from the
 {Central Maven repository}[https://repo1.maven.org/maven2/com/treasuredata/td-import/]
 and take advantage of these advanced features. If you need to setup a proxy, please consult this
-{documentation}[https://support.treasuredata.com/hc/en-us/articles/360001502527-Legacy-Bulk-Import-Tips-and-Tricks#How%20to%20use%20a%20proxy%20server] page.
+{documentation}[https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081765/Legacy+Bulk+Import+Tips+and+Tricks#Using-a-Proxy-Server] page.
 
 The log levels and properties of the Bulk Import CLI can be configured in a +logging.properties+ file. A default
 configuration is provided in a file within the gem or Toolbelt folder root, in the +java/+ folder. If you wish to

--- a/lib/td/command/account.rb
+++ b/lib/td/command/account.rb
@@ -41,7 +41,7 @@ module Command
       end
     end
 
-    $stdout.puts "Enter your Treasure Data credentials. For Google SSO user, please see https://support.treasuredata.com/hc/en-us/articles/360000720048-Treasure-Data-Toolbelt-Command-line-Interface#Google%20SSO%20Users"
+    $stdout.puts "Enter your Treasure Data credentials. For Google SSO user, please see https://tddocs.atlassian.net/wiki/spaces/PD/pages/1081668/Configuring+Authentication+for+TD+Using+the+TD+Toolbelt#Setting-Up-Google-SSO-Users"
     unless user_name
       begin
         $stdout.print "Email: "


### PR DESCRIPTION
Since TD doc is transferring to [new one](https://tddocs.atlassian.net/wiki/spaces/PD/overview), revised URLs within this tool.
Relate to https://github.com/treasure-data/td/pull/233