### PR TITLE
Force upgrade of yajl-ruby to at least 1.3.1, fixing CVE-2017-16516

### DIFF
--- a/td.gemspec
+++ b/td.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.1'
 
   gem.add_dependency "msgpack"
-  gem.add_dependency "yajl-ruby", "~> 1.1"
+  gem.add_dependency "yajl-ruby", "~> 1.3.1"
   gem.add_dependency "hirb", ">= 0.4.5"
   gem.add_dependency "parallel", "~> 1.8"
   gem.add_dependency "td-client", ">= 1.0.6", "< 2"


### PR DESCRIPTION
Updates the minimum version of the [yajl-ruby](https://github.com/brianmario/yajl-ruby) gem dependency to at least 1.3.1.  This is the minimum version necessary in order to mitigate [CVE-2017-16516](https://nvd.nist.gov/vuln/detail/CVE-2017-16516), which is present in yajl-ruby gem versions 1.3.0 and earlier.

`rake spec` tests passed successfully.

Environment:
* ruby 2.7.1
