### PR TITLE
Add missing licenses - Apache-2.0

### DIFF
--- a/td.gemspec
+++ b/td.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.executables           = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths         = ['lib']
   gem.required_ruby_version = '>= 2.1'
+  gem.licenses              = ["Apache-2.0"]
 
   gem.add_dependency "msgpack"
   gem.add_dependency "yajl-ruby", "~> 1.1"


### PR DESCRIPTION
It is better to add licenses explicitly in gemspec.

  % gem specification td | \grep licenses
  licenses: []

ref. https://guides.rubygems.org/specification-reference/