### PR TITLE
Allow trailing slash for endpoints

### DIFF
--- a/lib/td/config.rb
+++ b/lib/td/config.rb
@@ -148,7 +148,7 @@ class Config
 
 
   def self.endpoint
-    (@@endpoint || Config.read['account.endpoint']).sub(/(\/)+$/, '')
+    (@@endpoint || Config.read['account.endpoint'])&.sub(/(\/)+$/, '')
   end
 
   def self.endpoint=(endpoint)
@@ -156,7 +156,7 @@ class Config
   end
 
   def self.endpoint_domain
-    (self.endpoint || 'api.treasuredata.com').sub(%r[https?://], '')
+    (self.endpoint || 'api.treasuredata.com')&.sub(%r[https?://], '')
   end
 
   def self.cl_endpoint
@@ -168,7 +168,7 @@ class Config
   end
 
   def self.import_endpoint
-    (@@import_endpoint || Config.read['account.import_endpoint']).sub(/(\/)+$/, '')
+    (@@import_endpoint || Config.read['account.import_endpoint'])&.sub(/(\/)+$/, '')
   end
 
   def self.import_endpoint=(endpoint)

--- a/lib/td/config.rb
+++ b/lib/td/config.rb
@@ -148,7 +148,7 @@ class Config
 
 
   def self.endpoint
-    @@endpoint || Config.read['account.endpoint']
+    (@@endpoint || Config.read['account.endpoint']).sub(/(\/)+$/, '')
   end
 
   def self.endpoint=(endpoint)
@@ -168,7 +168,7 @@ class Config
   end
 
   def self.import_endpoint
-    @@import_endpoint || Config.read['account.import_endpoint']
+    (@@import_endpoint || Config.read['account.import_endpoint']).sub(/(\/)+$/, '')
   end
 
   def self.import_endpoint=(endpoint)

--- a/lib/td/config.rb
+++ b/lib/td/config.rb
@@ -148,7 +148,8 @@ class Config
 
 
   def self.endpoint
-    (@@endpoint || Config.read['account.endpoint'])&.sub(/(\/)+$/, '')
+    endpoint = @@endpoint || Config.read['account.endpoint']
+    endpoint.sub(/(\/)+$/, '') if endpoint
   end
 
   def self.endpoint=(endpoint)
@@ -156,7 +157,7 @@ class Config
   end
 
   def self.endpoint_domain
-    (self.endpoint || 'api.treasuredata.com')&.sub(%r[https?://], '')
+    (self.endpoint || 'api.treasuredata.com').sub(%r[https?://], '')
   end
 
   def self.cl_endpoint
@@ -168,7 +169,8 @@ class Config
   end
 
   def self.import_endpoint
-    (@@import_endpoint || Config.read['account.import_endpoint'])&.sub(/(\/)+$/, '')
+    endpoint = @@import_endpoint || Config.read['account.import_endpoint']
+    endpoint.sub(/(\/)+$/, '') if endpoint
   end
 
   def self.import_endpoint=(endpoint)

--- a/spec/td/config_spec.rb
+++ b/spec/td/config_spec.rb
@@ -84,6 +84,56 @@ describe TreasureData::Config do
     end
   end
 
+  describe 'allow endpoint with trailing slash' do
+    context 'self.endpoint' do
+      before { TreasureData::Config.endpoint = api_endpoint }
+      subject { TreasureData::Config.endpoint }
+
+      context 'api.treasuredata.com' do
+        let(:api_endpoint) { 'https://api.treasuredata.com/' }
+        it { is_expected.to eq 'https://api.treasuredata.com' }
+      end
+      context 'api.treasuredata.co.jp' do
+        let(:api_endpoint) { 'https://api.treasuredata.co.jp/' }
+        it { is_expected.to eq 'https://api.treasuredata.co.jp' }
+      end
+      context 'api.eu01.treasuredata.com' do
+        let(:api_endpoint) { 'https://api.eu01.treasuredata.com/' }
+        it { is_expected.to eq 'https://api.eu01.treasuredata.com' }
+      end
+      context 'api.ap02.treasuredata.com' do
+        let(:api_endpoint) { 'https://api.ap02.treasuredata.com/' }
+        it { is_expected.to eq 'https://api.ap02.treasuredata.com' }
+      end
+      context 'api-hoge.connect.treasuredata.com' do
+        let(:api_endpoint){ 'https://api-hoge.connect.treasuredata.com/' }
+        it { is_expected.to eq 'https://api-hoge.connect.treasuredata.com' }
+      end
+    end
+
+    context 'self.import_endpoint' do
+      before { TreasureData::Config.import_endpoint = api_endpoint }
+      subject { TreasureData::Config.import_endpoint }
+
+      context 'api-import.treasuredata.com' do
+        let(:api_endpoint) { 'https://api-import.treasuredata.com/' }
+        it { is_expected.to eq 'https://api-import.treasuredata.com' }
+      end
+      context 'api-import.treasuredata.co.jp' do
+        let(:api_endpoint) { 'https://api-import.treasuredata.co.jp/' }
+        it { is_expected.to eq 'https://api-import.treasuredata.co.jp' }
+      end
+      context 'api-import.eu01.treasuredata.com' do
+        let(:api_endpoint) { 'https://api-import.eu01.treasuredata.com/' }
+        it { is_expected.to eq 'https://api-import.eu01.treasuredata.com' }
+      end
+      context 'api-import.ap02.treasuredata.com' do
+        let(:api_endpoint) { 'https://api-import.ap02.treasuredata.com/' }
+        it { is_expected.to eq 'https://api-import.ap02.treasuredata.com' }
+      end
+    end
+  end
+
   describe '#read' do
     it 'sets @conf' do
       Tempfile.create('td.conf') do |f|


### PR DESCRIPTION
Currently, TD Toolbelt allows endpoints as follows:
- schema + host
- host

As we set endpoint with trailing slash in td.conf and/or environment variables such as `https://example.com/`, TD returns like:

```
$ td wf
TreasureData account is not configured yet.
Run 'td account' first.
```

It confuses users because the message doesn't tell us that
`account.endpoint` or environment vairables of endpoint is invalid.
Thus, I propose that the tool allows users to tailing slash as the endpoint
URIs.

What do you think about it?