### PR TITLE
Support AP03 Region

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 
 orbs:
-  ruby: circleci/ruby@1.1.2 
+  ruby: circleci/ruby@1.1.4 
   win: circleci/windows@2.4.0
 
 

--- a/lib/td/command/common.rb
+++ b/lib/td/command/common.rb
@@ -67,13 +67,11 @@ module Command
     Client.new(apikey, opts)
   end
 
-  DEFAULT_IMPORT_ENDPOINT = "https://" + TreasureData::API::DEFAULT_IMPORT_ENDPOINT
-
   def get_import_client
     import_endpoint = begin
-                        Config.import_endpoint || DEFAULT_IMPORT_ENDPOINT
+                        Config.import_endpoint || nil
                       rescue TreasureData::ConfigNotFoundError
-                        DEFAULT_IMPORT_ENDPOINT
+                        nil
                       end
     get_client(endpoint: import_endpoint)
   end

--- a/lib/td/config.rb
+++ b/lib/td/config.rb
@@ -187,7 +187,7 @@ class Config
 
   def self.workflow_endpoint
     case self.endpoint_domain
-    when /\Aapi(-(?:staging|development))?(-[a-z0-9]+)?\.(connect\.)?((?:eu01|ap02)\.)?treasuredata\.(com|co\.jp)\z/i
+    when /\Aapi(-(?:staging|development))?(-[a-z0-9]+)?\.(connect\.)?((?:eu01|ap02|ap03)\.)?treasuredata\.(com|co\.jp)\z/i
       "https://api#{$1}-workflow#{$2}.#{$3}#{$4}treasuredata.#{$5}"
     else
       raise ConfigError, "Workflow is not supported for '#{self.endpoint}'"

--- a/spec/td/config_spec.rb
+++ b/spec/td/config_spec.rb
@@ -32,6 +32,10 @@ describe TreasureData::Config do
       let(:api_endpoint){ 'api.ap02.treasuredata.com' }
       it { is_expected.to eq 'https://api-workflow.ap02.treasuredata.com' }
     end
+    context 'api.ap03.treasuredata.com' do
+      let(:api_endpoint){ 'api.ap03.treasuredata.com' }
+      it { is_expected.to eq 'https://api-workflow.ap03.treasuredata.com' }
+    end
 
     context 'api-hoge.connect.treasuredata.com' do
       let(:api_endpoint){ 'api-hoge.connect.treasuredata.com' }
@@ -58,6 +62,10 @@ describe TreasureData::Config do
       let(:api_endpoint){ 'api-staging.ap02.treasuredata.com' }
       it { is_expected.to eq 'https://api-staging-workflow.ap02.treasuredata.com' }
     end
+    context 'api-staging.ap03.treasuredata.com' do
+      let(:api_endpoint){ 'api-staging.ap03.treasuredata.com' }
+      it { is_expected.to eq 'https://api-staging-workflow.ap03.treasuredata.com' }
+    end
 
     context 'api-development.treasuredata.com' do
       let(:api_endpoint){ 'api-development.treasuredata.com' }
@@ -74,6 +82,10 @@ describe TreasureData::Config do
     context 'api-development.ap02.treasuredata.com' do
       let(:api_endpoint){ 'api-development.ap02.treasuredata.com' }
       it { is_expected.to eq 'https://api-development-workflow.ap02.treasuredata.com' }
+    end
+    context 'api-development.ap03.treasuredata.com' do
+      let(:api_endpoint){ 'api-development.ap03.treasuredata.com' }
+      it { is_expected.to eq 'https://api-development-workflow.ap03.treasuredata.com' }
     end
 
     context 'ybi.jp-east.idcfcloud.com' do
@@ -105,6 +117,10 @@ describe TreasureData::Config do
         let(:api_endpoint) { 'https://api.ap02.treasuredata.com/' }
         it { is_expected.to eq 'https://api.ap02.treasuredata.com' }
       end
+      context 'api.ap03.treasuredata.com' do
+        let(:api_endpoint) { 'https://api.ap03.treasuredata.com/' }
+        it { is_expected.to eq 'https://api.ap03.treasuredata.com' }
+      end
       context 'api-hoge.connect.treasuredata.com' do
         let(:api_endpoint){ 'https://api-hoge.connect.treasuredata.com/' }
         it { is_expected.to eq 'https://api-hoge.connect.treasuredata.com' }
@@ -130,6 +146,10 @@ describe TreasureData::Config do
       context 'api-import.ap02.treasuredata.com' do
         let(:api_endpoint) { 'https://api-import.ap02.treasuredata.com/' }
         it { is_expected.to eq 'https://api-import.ap02.treasuredata.com' }
+      end
+      context 'api-import.ap03.treasuredata.com' do
+        let(:api_endpoint) { 'https://api-import.ap03.treasuredata.com/' }
+        it { is_expected.to eq 'https://api-import.ap03.treasuredata.com' }
       end
     end
   end


### PR DESCRIPTION
There are two changes needed to support AP03:
- Update workflow regex pattern to support AP03 (in config.rb)
- Fix bug when no import_endpoint setting a met. If so, import endpoint should default to nil and get handled by td-client-ruby instead of defaulting to DEFAULT_IMPORT_ENDPOINT. (in common.rb)