### PR TITLE
Increase the summary_width value to fix the broken options help message format

### DIFF
--- a/lib/td/command/export.rb
+++ b/lib/td/command/export.rb
@@ -103,8 +103,6 @@ module Command
       raise ArgumentError, "#{s} is not a supported encryption method" unless SUPPORTED_ENCRYPT_METHOD.include?(s)
       encryption = s
     }
-    # Increase the summary_width value from default 32 into 36, to show the options help message properly.
-    op.summary_width = 36
     op.on('-a', '--assume-role ASSUME_ROLE_ARN', 'export with assume role with ASSUME_ROLE_ARN as role arn') {|s|
       assume_role = s
     }

--- a/lib/td/command/export.rb
+++ b/lib/td/command/export.rb
@@ -67,6 +67,9 @@ module Command
     encryption = nil
     assume_role = nil
 
+    # Increase the summary_width value from default 32 into 36, to show the options help message properly.
+    op.summary_width = 36
+
     op.on('-w', '--wait', 'wait until the job is completed', TrueClass) {|b|
       wait = b
     }

--- a/lib/td/command/export.rb
+++ b/lib/td/command/export.rb
@@ -103,6 +103,8 @@ module Command
       raise ArgumentError, "#{s} is not a supported encryption method" unless SUPPORTED_ENCRYPT_METHOD.include?(s)
       encryption = s
     }
+    # Increase the summary_width value from default 32 into 36, to show the options help message properly.
+    op.summary_width = 36
     op.on('-a', '--assume-role ASSUME_ROLE_ARN', 'export with assume role with ASSUME_ROLE_ARN as role arn') {|s|
       assume_role = s
     }

--- a/lib/td/command/runner.rb
+++ b/lib/td/command/runner.rb
@@ -28,8 +28,6 @@ usage: #{$prog} [options] COMMAND [args]
 options:
 EOF
 
-    # Increase the summary_width value from default 32 into 36, to show the options help message properly.
-    op.summary_width = 36
     op.summary_indent = "  "
 
     (class << self;self;end).module_eval do

--- a/lib/td/command/runner.rb
+++ b/lib/td/command/runner.rb
@@ -28,6 +28,8 @@ usage: #{$prog} [options] COMMAND [args]
 options:
 EOF
 
+    # Increase the summary_width value from default 32 into 36, to show the options help message properly.
+    op.summary_width = 36
     op.summary_indent = "  "
 
     (class << self;self;end).module_eval do


### PR DESCRIPTION
The summary width of `--assume-role` option in `table:export` help message is exceeding the current default value (32), so the help message for `--assume-role` option is broken.

```
# td table:export
usage:
  $ td table:export <db> <table>

......

  -e, --encryption ENCRYPT_METHOD  export with server side encryption with the ENCRYPT_METHOD
  -a ASSUME_ROLE_ARN,              export with assume role with ASSUME_ROLE_ARN as role arn
      --assume-role
```

To fix the broken help message for `--assume-role` option, we need to increase the summary width. From here, we increase the value to 36. After increasing the summary width, we can see the proper help message for `--assume-role` option as the following:

```
# td table:export
usage:
  $ td table:export <db> <table>

......

  -e, --encryption ENCRYPT_METHOD      export with server side encryption with the ENCRYPT_METHOD
  -a, --assume-role ASSUME_ROLE_ARN    export with assume role with ASSUME_ROLE_ARN as role arn
```