### PR TITLE
Pin parallel version to support ruby 2.4.5

### DIFF
--- a/td.gemspec
+++ b/td.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rexml"
   gem.add_dependency "yajl-ruby", "~> 1.3.1"
   gem.add_dependency "hirb", ">= 0.4.5"
-  gem.add_dependency "parallel", "~> 1.8"
+  gem.add_dependency "parallel", "~> 1.20.0"
   gem.add_dependency "td-client", ">= 1.0.8", "< 2"
   gem.add_dependency "td-logger", ">= 0.3.21", "< 2"
   gem.add_dependency "rubyzip", "~> 1.3.0"


### PR DESCRIPTION
Parallel version latter than 1.20 only support Ruby 2.5 and up. We need to pin parallel to version 1.20.x to support ruby 2.4.5.