### PR TITLE
Bug fixes for installing and updating in Windows

### DIFF
--- a/dist/resources/exe/td.iss
+++ b/dist/resources/exe/td.iss
@@ -22,6 +22,9 @@ Name: custom; Description: "Custom Installation"; flags: iscustom
 Name: "toolbelt"; Description: "Treasure Data Toolbelt"; Types: "client custom"
 Name: "toolbelt/client"; Description: "Treasure Data Client"; Types: "client custom"; Flags: fixed
 
+[InstallDelete]
+Type: filesandordirs; Name: "{app}\vendor"
+
 [Files]
 Source: "td\*.*"; DestDir: "{app}"; Flags: recursesubdirs; Components: "toolbelt/client"
 Source: "installers\rubyinstaller.exe"; DestDir: "{tmp}"; Components: "toolbelt/client"

--- a/lib/td/updater.rb
+++ b/lib/td/updater.rb
@@ -150,6 +150,7 @@ module ModuleDefinition
   end
 
   def update(autoupdate = false)
+    FileUtils.mkdir_p File.dirname(updating_lock_path)
     wait_for_lock(updating_lock_path, 5) do
       require "td"
       require 'open-uri'


### PR DESCRIPTION
This PR includes fixes for:
1. td gem version does not load correctly because previous versions also exists. Solution is to remove vendor/ folder first in the installing process.
2. `td update` throws exception if folder `.td` does not exist in HOME directory.