### PR TITLE
Relax required version of yajl-ruby

### DIFF
--- a/td.gemspec
+++ b/td.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "msgpack"
   gem.add_dependency "rexml"
-  gem.add_dependency "yajl-ruby", "~> 1.3.1"
+  gem.add_dependency "yajl-ruby", ">= 1.3.1", "< 2.0"
   gem.add_dependency "hirb", ">= 0.4.5"
   gem.add_dependency "parallel", "~> 1.20.0"
   gem.add_dependency "td-client", ">= 1.0.8", "< 2"


### PR DESCRIPTION
td-0.16.10 doesn't accept latest yajl-ruby (1.4.1) although td-0.16.9
accepts it (`>~ 1.3.1` means `>= 1.3.1, < 1.4`).
Probably fc71ccdb2c9a88cd72ba4262f493c81291fb3ac6 doesn't intend to
reject it, it seems a mistake:

    Force upgrade of yujl-ruby to at least 1.3.1, fixing CVE-2017-16516 (#235)

Signed-off-by: Takuro Ashie <ashie@clear-code.com>