### PR TITLE
Update Ruby image for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 
 orbs:
-  ruby: circleci/ruby@1.1.4 
+  ruby: circleci/ruby@1.2.0
   win: circleci/windows@2.4.0
 
 
@@ -42,35 +42,31 @@ commands:
 jobs:
 
   ruby_25:
-    machine:
-      image: ubuntu-1604:202004-01
+    docker:
+      - image: cimg/ruby:2.5.9
+    executor: ruby/default
     steps:
-      - ruby/install:
-          version: '2.5'
       - run-tests-flow
 
   ruby_26:
-    machine:
-      image: ubuntu-1604:202004-01
+    docker:
+      - image: cimg/ruby:2.6.8
+    executor: ruby/default
     steps:
-      - ruby/install:
-          version: '2.6'
       - run-tests-flow
 
   ruby_27:
-    machine:
-      image: ubuntu-1604:202004-01
+    docker:
+      - image: cimg/ruby:2.7.4
+    executor: ruby/default
     steps:
-      - ruby/install:
-          version: '2.7'
       - run-tests-flow
 
   ruby_30:
-    machine:
-      image: ubuntu-1604:202004-01
+    docker:
+      - image: cimg/ruby:3.0.2
+    executor: ruby/default
     steps:
-      - ruby/install:
-          version: '3.0'
       - run-tests-flow
 
   win_ruby:


### PR DESCRIPTION
The current pull request got CI failure because Ruby installation is failed:

```
#!/bin/bash -eo pipefail
# Disable IPv6
mkdir -p ~/.gnupg/
find ~/.gnupg -type d -exec chmod 700 {} \;
echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf

count=0
until gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
do
    count=$((count+1)); sleep 10;
    if [ $count -gt 2 ]; then
        echo "Unable to receive GPG keys, FAILING";
        exit 1;
    fi;
    echo "Network error: Unable to receive GPG keys. Will attempt again ($count/3)";
done;
## Update if RVM is installed and exit
if [ -x "$(command -v rvm -v)" ]; then
    rvm get stable
    exit 0
fi

curl -sSL "https://get.rvm.io" | bash -s stable
# this should be what needs to be added to that $BASH_ENV since this is what's in bash_profile - i dont know when $HOME is set
echo 'export PATH=$PATH:$HOME/.rvm/bin' >> $BASH_ENV
echo "source $HOME/.rvm/scripts/rvm" >> $BASH_ENV
# this will source if anyone logs in noninteractively, nvm setup only adds nvm to the path, to get the rubygems later you need to source this again
echo "source $HOME/.rvm/scripts/rvm" >> ~/.bashrc

gpg: requesting key D39DC0E3 from hkp server keyserver.ubuntu.com
gpg: requesting key 39499BDB from hkp server keyserver.ubuntu.com
gpg: key D39DC0E3: "Michal Papis (RVM signing) <mpapis@gmail.com>" not changed
gpg: key 39499BDB: public key "Piotr Kuczynski <piotr.kuczynski@gmail.com>" imported
gpg: no ultimately trusted keys found
gpg: Total number processed: 2
gpg:               imported: 1  (RSA: 1)
gpg:              unchanged: 1
Warning! PATH is not properly set up, /opt/circleci/.rvm/gems/ruby-2.7.1/bin is not at first place.
         <log>Usually this is caused by shell initialization files. Search for <code>PATH=...</code> entries.
         You can also re-add RVM to your profile by running: <code>rvm get stable --auto-dotfiles</code>
         To fix it temporarily in this shell session run: <code>rvm use ruby-2.7.1</code>
         To ignore this error add <code>rvm_silence_path_mismatch_check_flag=1</code> to your <code>~/.rvmrc</code> file.
Downloading https://get.rvm.io
Could not download rvm-installer, please report to https://github.com/rvm/rvm/issues

Exited with code exit status 60
CircleCI received exit code 60
```

So that update images, see:
* https://circleci.com/developer/orbs/orb/circleci/ruby
* https://circleci.com/developer/images/image/cimg/ruby