### PR TITLE
Fix account command error on windows

### DIFF
--- a/lib/td/command/account.rb
+++ b/lib/td/command/account.rb
@@ -113,12 +113,16 @@ module Command
 
   private
   if Helpers.on_windows?
-    require 'Win32API'
+    require 'fiddle'
 
     def get_char
-      Win32API.new('msvcrt', '_getch', [], 'L').Call
+      msvcrt = Fiddle.dlopen('msvcrt')
+      getch = Fiddle::Function.new(msvcrt['_getch'], [], Fiddle::TYPE_CHAR)
+      getch.call()
     rescue Exception
-      Win32API.new('crtdll', '_getch', [], 'L').Call
+      crtdll = Fiddle.dlopen('crtdll')
+      getch = Fiddle::Function.new(crtdll['_getch'], [], Fiddle::TYPE_CHAR)
+      getch.call()
     end
 
     def get_password

--- a/spec/td/command/account_spec.rb
+++ b/spec/td/command/account_spec.rb
@@ -1,0 +1,56 @@
+# encoding: utf-8
+
+require 'spec_helper'
+require "tempfile"
+require 'td/command/common'
+require 'td/command/account'
+require 'td/command/list'
+
+module TreasureData::Command
+  describe 'account command' do
+    let :command do
+      Class.new { include TreasureData::Command }.new
+    end
+    let(:client) { double(:client) }
+    let(:conf_file) { Tempfile.new("td.conf").tap {|s| s.close } }
+    let(:conf_expect) {
+"""[account]
+  user = test@email.com
+  apikey = 1/xxx
+"""
+    }
+
+    before do
+      TreasureData::Config.path = conf_file.path
+      $stdout.puts "conf_file.path " + conf_file.path
+    end
+
+    it 'is called without any option' do
+      expect(STDIN).to receive(:gets).and_return('test@email.com')
+      expect(STDIN).to receive(:gets).and_return('password')
+      expect(TreasureData::Client).to receive(:authenticate).and_return(client)
+      expect(client).to receive(:apikey).and_return("1/xxx")
+      op = List::CommandParser.new("account", %w[], %w[], false, [], true)
+      command.account(op)
+      expect(File.read(conf_file.path)).to eq(conf_expect)
+    end
+
+    it 'is called with -f option' do
+      expect(STDIN).to receive(:gets).and_return('password')
+      expect(TreasureData::Client).to receive(:authenticate).and_return(client)
+      expect(client).to receive(:apikey).and_return("1/xxx")
+      op = List::CommandParser.new("account", %w[-f], %w[], false, ['test@email.com'], true)
+      command.account(op)
+      expect(File.read(conf_file.path)).to eq(conf_expect)
+    end
+
+    it 'is called with username password mismatched' do
+      expect(STDIN).to receive(:gets).and_return('password').thrice
+      expect(TreasureData::Client).to receive(:authenticate).thrice.and_raise(TreasureData::AuthError)
+      expect(STDERR).to receive(:puts).with('User name or password mismatched.').thrice
+      op = List::CommandParser.new("account", %w[-f], %w[], false, ['test@email.com'], true)
+      command.account(op)
+      expect(File.read(conf_file.path)).to eq("")
+    end
+  end
+end

--- a/td.gemspec
+++ b/td.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rubyzip", "~> 1.3.0"
   gem.add_dependency "zip-zip", "~> 0.3"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
-  gem.add_dependency "win32api", "~> 0.1.0"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency 'webrick'

--- a/td.gemspec
+++ b/td.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rubyzip", "~> 1.3.0"
   gem.add_dependency "zip-zip", "~> 0.3"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
+  gem.add_dependency "win32api", "~> 0.1.0"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency 'webrick'


### PR DESCRIPTION
### Purpose
Ruby 3 has dropped `Win32API` gem, causing `td account` command to fail. We need to replace ` Win32API` with `fiddle`.

### Overview
- Use `fiddle` directly for getting password in Windows.
- Add tests for account command.

### Impact
- Windows builds