### PR TITLE
Update password symbol for user creation

### DIFF
--- a/lib/td/command/user.rb
+++ b/lib/td/command/user.rb
@@ -64,7 +64,7 @@ module Command
       lower = ('a'..'z').to_a
       upper = ('A'..'Z').to_a
       digit = ('0'..'9').to_a
-      symbol = %w[_ @ - + ;]
+      symbol = %w[! # $ % - _ = + < >]
 
       r = []
       3.times { r << lower.sort_by{rand}.first }


### PR DESCRIPTION
When we run `td user:create name -e {email_address} -R`, the generated random password includes `_`, `@`, `-`, `+` or `;`.
However, our current password rule requires other symbols: ! # $ % - _ = + < >. It means the current random password option has the possibility to violate a user's password policy.

Thus, I propose updating the characters which are used in `--random-password` option.
Although I couldn't add a test case because the password validation depends on TD account's setting and our API doesn't return the password. However, it worked on our local machine.

```
% be td user:create dummy-name -e {my_email_address} -R 
Password: EZdBr<8e0
User 'dummy-name' is created.
Use 'td user:apikeys dummy-name' to show the API key.
```