### PR TITLE
Support td-client 2.x.x

### DIFF
--- a/spec/td/command/workflow_spec.rb
+++ b/spec/td/command/workflow_spec.rb
@@ -12,7 +12,7 @@ def java_available?
   if not status.success?
     return false
   end
-  if output !~ /(openjdk|java) version "1/
+  if output !~ /(openjdk|java) version "(1|2)/
     return false
   end
   return true

--- a/td.gemspec
+++ b/td.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "yajl-ruby", ">= 1.3.1", "< 2.0"
   gem.add_dependency "hirb", ">= 0.4.5"
   gem.add_dependency "parallel", "~> 1.20.0"
-  gem.add_dependency "td-client", ">= 1.0.8", "< 2"
+  gem.add_dependency "td-client", ">= 1.0.8", "< 3"
   gem.add_dependency "td-logger", ">= 0.3.21", "< 2"
   gem.add_dependency "rubyzip", "~> 1.3.0"
   gem.add_dependency "zip-zip", "~> 0.3"


### PR DESCRIPTION
As td-client gem version 2.0.0 is now available https://github.com/treasure-data/td-client-ruby/releases/tag/v2.0.0, we need to support it in td cli