### PR TITLE
Use https://toolbelt.treasuredata.com/ for TD Toolbelt's download URL consistently

### DIFF
--- a/bin/td
+++ b/bin/td
@@ -9,7 +9,7 @@ require 'td/updater'
 TreasureData::Updater.disable(<<EOS
 
 `td update` is only available from the Treasure Data Toolbelt.
-You can download and install it from http://toolbelt.treasure-data.com.
+You can download and install it from http://toolbelt.treasuredata.com.
 
 It appers you are running the `td` gem. To update the gem to the latest
 version, please run `gem update td`.

--- a/lib/td/command/workflow.rb
+++ b/lib/td/command/workflow.rb
@@ -140,7 +140,7 @@ module TreasureData
     end
 
     def digdag_base_url(version=nil)
-      base = 'https://toolbelt.treasure-data.com/digdag'
+      base = 'https://toolbelt.treasuredata.com/digdag'
       if version.to_s == ''
         base
       else

--- a/spec/td/command/workflow_spec.rb
+++ b/spec/td/command/workflow_spec.rb
@@ -161,7 +161,7 @@ EOF
         expect(TreasureData::Updater).to_not have_received(:stream_fetch).with(
             %r{/java/}, instance_of(File))
         expect(TreasureData::Updater).to have_received(:stream_fetch).with(
-            'https://toolbelt.treasure-data.com/digdag?user=test%40example.com', instance_of(File))
+            'https://toolbelt.treasuredata.com/digdag?user=test%40example.com', instance_of(File))
       end
 
       it 'installs java + digdag and can run a workflow' do
@@ -180,7 +180,7 @@ EOF
         expect(stdout_io.string).to include 'Downloading workflow module'
         expect(File).to exist(File.join(ENV[home_env], '.td', 'digdag', 'digdag'))
         expect(TreasureData::Updater).to have_received(:stream_fetch).with(
-            'https://toolbelt.treasure-data.com/digdag?user=test%40example.com', instance_of(File))
+            'https://toolbelt.treasuredata.com/digdag?user=test%40example.com', instance_of(File))
 
         # Check that java and digdag is not re-installed
         stdout_io.truncate(0)
@@ -228,7 +228,7 @@ EOF
           expect(TreasureData::Updater).to_not have_received(:stream_fetch).with(
               %r{/java/}, instance_of(File))
           expect(TreasureData::Updater).to have_received(:stream_fetch).with(
-              'https://toolbelt.treasure-data.com/digdag?user=test%40example.com', instance_of(File))
+              'https://toolbelt.treasuredata.com/digdag?user=test%40example.com', instance_of(File))
 
           # Check that digdag is not re-installed
           stdout_io.truncate(0)
@@ -250,7 +250,7 @@ EOF
           expect(stdout_io.string).to include 'Downloading workflow module'
           expect(File).to exist(File.join(ENV[home_env], '.td', 'digdag', 'digdag'))
           expect(TreasureData::Updater).to have_received(:stream_fetch).with(
-              'https://toolbelt.treasure-data.com/digdag', instance_of(File))
+              'https://toolbelt.treasuredata.com/digdag', instance_of(File))
         }
       end
 


### PR DESCRIPTION
So far there are 2 URLs are used to reference TD Toolbelt's download URL.

* https://toolbelt.treasuredata.com/
* https://toolbelt.treasure-data.com/

Since there is no particular reason to use 2 distinct URLs for it, I'd like to make it consistent to use https://toolbelt.treasuredata.com/ as the download URL for TD Toolbelt.