### PR TITLE
Fix win_ruby ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,26 @@ orbs:
 commands:
   install_windows_requirements:
     description: "Install windows requirements"
+    parameters:
+      ruby_version:
+        type: string
+        default: "latest"
     steps:
       - run:
           name: "Install MSYS2"
+          shell: powershell.exe
           command: choco install msys2 -y
       - run:
           name: "Install Ruby devkit"
+          shell: powershell.exe
           command: ridk install 2 3
+      - run:
+          name: "Install Ruby version"
+          shell: powershell.exe
+          command: choco install ruby --version=<<parameters.ruby_version>>
+      - run:
+          name: "Install bundler"
+          command: gem install bundler
   bundle-install:
     description: "Install dependencies"
     steps:
@@ -70,11 +83,8 @@ jobs:
       name: win/default
       shell: powershell.exe
     steps:
-      - install_windows_requirements
-      - run:
-          name: "Install bundler"
-          shell: powershell.exe
-          command: gem install bundler
+      - install_windows_requirements:
+          ruby_version: "3.4.4.2"
       - run-tests-flow
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,18 @@ jobs:
     steps:
       - run-tests-flow
 
+  ruby_33:
+    docker:
+      - image: cimg/ruby:3.3-browsers
+    steps:
+      - run-tests-flow
+
+  ruby_34:
+    docker:
+      - image: cimg/ruby:3.4-browsers
+    steps:
+      - run-tests-flow
+
   win_ruby:
     executor:
       name: win/default
@@ -95,4 +107,6 @@ workflows:
       - ruby_30
       - ruby_31
       - ruby_32
+      - ruby_33
+      - ruby_34
       - win_ruby

--- a/td.gemspec
+++ b/td.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rubyzip", "~> 1.3.0"
   gem.add_dependency "zip-zip", "~> 0.3"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
+  gem.add_dependency "csv"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency 'webrick'


### PR DESCRIPTION
- Fix failing win_ruby CI job
- Add `csv` dependency for Ruby 3.4
- Add CI jobs for Ruby 3.3 & 3.4