### PR TITLE
Support :trino parameter when selecting a query type

### DIFF
--- a/lib/td/command/job.rb
+++ b/lib/td/command/job.rb
@@ -28,6 +28,8 @@ module Command
     /\A[\+]?2\z/ => 2,
   }
 
+  QUERY_JOB_TYPES = [:hive, :pig, :impala, :presto, :trino].freeze
+
   def job_list(op)
     page = 0
     skip = 0
@@ -176,7 +178,7 @@ private
     $stdout.puts "Start At    : #{job.start_at}"
     $stdout.puts "End At      : #{job.end_at}"
     # exclude some fields from bulk_import_perform type jobs
-    if [:hive, :pig, :impala, :presto].include?(job.type)
+    if QUERY_JOB_TYPES.include?(job.type)
       $stdout.puts "Priority    : #{job_priority_name_of(job.priority)}"
       $stdout.puts "Retry limit : #{job.retry_limit}"
       $stdout.puts "Output      : #{job.result_url}"
@@ -192,7 +194,7 @@ private
       if [:hive].include?(job.type)
         $stdout.puts "CPU time    : #{Command.humanize_time(job.cpu_time, true)}"
       end
-      if [:hive, :pig, :impala, :presto].include?(job.type)
+      if QUERY_JOB_TYPES.include?(job.type)
         $stdout.puts "Result size : #{Command.humanize_bytesize(job.result_size, 2)}"
       end
     end
@@ -200,11 +202,11 @@ private
     if wait && !job.finished?
       $stderr.puts "the job #{job.job_id} is still running..."
       wait_job(job)
-      if [:hive, :pig, :impala, :presto].include?(job.type) && !exclude
+      if QUERY_JOB_TYPES.include?(job.type) && !exclude
         show_result_with_retry(job, output, limit, format, render_opts)
       end
     else
-      if [:hive, :pig, :impala, :presto].include?(job.type) && !exclude && job.finished?
+      if QUERY_JOB_TYPES.include?(job.type) && !exclude && job.finished?
         show_result_with_retry(job, output, limit, format, render_opts)
       end
 

--- a/lib/td/command/query.rb
+++ b/lib/td/command/query.rb
@@ -65,7 +65,7 @@ module Command
     op.on('-q', '--query PATH', 'use file instead of inline query') {|s|
       query = File.open(s) { |f| f.read.strip }
     }
-    op.on('-T', '--type TYPE', 'set query type (hive, trino)') {|s|
+    op.on('-T', '--type TYPE', 'set query type (hive, presto, trino)') {|s|
       type = s.to_sym
     }
     op.on('--sampling DENOMINATOR', 'OBSOLETE - enable random sampling to reduce records 1/DENOMINATOR', Integer) {|i|

--- a/lib/td/command/sched.rb
+++ b/lib/td/command/sched.rb
@@ -77,7 +77,7 @@ module Command
     op.on('-R', '--retry COUNT', 'automatic retrying count', Integer) {|i|
       retry_limit = i
     }
-    op.on('-T', '--type TYPE', 'set query type (hive)') {|s|
+    op.on('-T', '--type TYPE', 'set query type (hive, presto, trino)') {|s|
       type = s
     }
     op.on('--engine-version ENGINE_VERSION', 'EXPERIMENTAL: specify query engine version by name') {|s|
@@ -195,7 +195,7 @@ module Command
     op.on('-R', '--retry COUNT', 'automatic retrying count', Integer) {|i|
       retry_limit = i
     }
-    op.on('-T', '--type TYPE', 'set query type (hive)') {|s|
+    op.on('-T', '--type TYPE', 'set query type (hive, presto, trino)') {|s|
       type = s
     }
     op.on('--engine-version ENGINE_VERSION', 'EXPERIMENTAL: specify query engine version by name') {|s|


### PR DESCRIPTION
`td` hasn't allowed users to run Trino query even though we have already supported td-client-ruby v3:

```
% td query -T trino -d sample_datasets "select * www_access limit 10"
Error ArgumentError: backtrace:
  /Users/akito.kasai/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/td-client-1.0.8/lib/td/client.rb:194:in 'TreasureData::Client#query'
  /Users/akito.kasai/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/td-0.17.1/lib/td/command/query.rb:148:in 'TreasureData::Command#query'
  /Users/akito.kasai/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/td-0.17.1/lib/td/command/list.rb:171:in 'Method#call'
  /Users/akito.kasai/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/td-0.17.1/lib/td/command/list.rb:171:in 'block in TreasureData::Command::List.get_method'
  /Users/akito.kasai/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/td-0.17.1/lib/td/command/runner.rb:186:in 'TreasureData::Command::Runner#run'
  /Users/akito.kasai/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/td-0.17.1/bin/td:27:in '<top (required)>'
  /Users/akito.kasai/.rbenv/versions/3.4.1/bin/td:25:in 'Kernel#load'
  /Users/akito.kasai/.rbenv/versions/3.4.1/bin/td:25:in '<main>'
  ```
  
We have new command line interface `tdx`, but I think it will not be bad to follow up out new parameter.

```
% ./bin/td query -T trino -d sample_datasets "select * www_access limit 10"
Job 2948945397 is queued.
Use 'td job:show 2948945397' to show the status.
```